### PR TITLE
[#16] Skills: Fix squash commit format and enforce sub-branching

### DIFF
--- a/.claude/skills/gh-sdlc/SKILL.md
+++ b/.claude/skills/gh-sdlc/SKILL.md
@@ -32,9 +32,7 @@ There are two ways users invoke this workflow:
 The user invokes `/gh-sdlc <objective>` or describes an objective alongside the SDLC trigger BEFORE starting work. Run the full pipeline from Phase 1 (planning) through Phase 5 (tracking), including implementation.
 
 ### B) Retroactive: Ship completed work
-The user has already done the work (code is written, changes exist) and now invokes `/gh-sdlc` or says "commit" / "ship it" to formalize it. Analyze the session's completed work (git diff, changed files, session context) and run the pipeline — proper decomposition, issues, project tracking, branching, atomic commits, PR, merge.
-
-**Phase 2 (Implementation) is skipped** — the code already exists. Instead, during branching (Phase 1) and commit/PR (Phase 3), analyze the existing diff and stage changes into proper atomic commits on the correct branch(es).
+The user has already done the work (code is written, changes exist) and now invokes `/gh-sdlc` or says "commit" / "ship it" to formalize it. Analyze the session's completed work (git diff, changed files, session context) and run the full pipeline — proper decomposition, issues, project tracking, commits, PR, merge. Do NOT skip steps just because code already exists.
 
 **In both cases**, proper decomposition, issue creation, project tracking, branching, atomic commits, and PR creation MUST happen. The only difference is whether implementation occurs during the workflow (A) or has already occurred before it (B).
 
@@ -123,6 +121,7 @@ This workflow orchestrates four policy skills:
 5. **Create branches:**
    - Parent: `feature/<parent-number>-<description>`
    - Children: `feature/<parent-number>/<child-number>-<description>`
+   - **Always** create sub-branches for sub-issues — if the issue was decomposed, the branch must be too
 
 ### Phase 2: Implementation (commit-policy)
 
@@ -139,6 +138,8 @@ This workflow orchestrates four policy skills:
    ```bash
    git commit --fixup=<target-hash>
    ```
+
+**For retroactive use (Use Case B):** Code already exists. Analyze the diff, create the branch, stage and commit changes with proper atomic commits and messages. Do not re-implement — just formalize.
 
 ### Phase 3: PR Creation (pr-policy + gh-projects)
 

--- a/.claude/skills/issue-policy/SKILL.md
+++ b/.claude/skills/issue-policy/SKILL.md
@@ -187,6 +187,8 @@ graph TD
 - `feature/1/3-core-bot-client`
 - `bugfix/56-null-pointer-handler`
 
+**Rule:** When child issues exist, ALWAYS create corresponding sub-branches. Every child issue gets its own `feature/parent/child-description` branch — no exceptions. Sub-branches mirror sub-issues: if you decomposed the issue, decompose the branch.
+
 ## Issue Lifecycle
 
 ```

--- a/.claude/skills/pr-policy/SKILL.md
+++ b/.claude/skills/pr-policy/SKILL.md
@@ -113,7 +113,7 @@ Use for:
 
 **Squash commit message format:**
 ```
-[#issue] Component: Description (#pr)
+gh-<issue>: <imperative description> (#pr)
 
 - Key change 1
 - Key change 2
@@ -171,6 +171,8 @@ main
     ├── feature/1/2-child-issue-one
     └── feature/1/3-child-issue-two
 ```
+
+**Rule:** When child issues exist, ALWAYS create corresponding sub-branches. Every child issue gets its own `feature/parent/child-description` branch. Sub-branches mirror sub-issues — if you decomposed the issue, decompose the branch.
 
 **Merge order:** Children → Parent → Main
 


### PR DESCRIPTION
## Changes

- Fixed squash commit message format in pr-policy from `[#issue] Component: Description (#pr)` to `gh-<issue>: <imperative description> (#pr)` to match commit-policy
- Added mandatory sub-branching rule: when child issues exist, corresponding sub-branches must always be created
- Rule added consistently across issue-policy, pr-policy, and gh-sdlc

## Issue Reference

Closes #16

## Testing

- [x] All three skills updated consistently
- [x] Synced to both `~/.claude/skills/` and repo
- [x] Self-reviewed diff

## Checklist

- [x] Code follows project style guide
- [x] Documentation updated
- [x] No debugging artifacts
- [x] Commit history is clean
- [x] Self-reviewed diff