### PR TITLE
gh-33: use Development sidebar linking instead of Issue Reference section

### DIFF
--- a/plugins/gh-sdlc/skills/gh-sdlc/SKILL.md
+++ b/plugins/gh-sdlc/skills/gh-sdlc/SKILL.md
@@ -246,7 +246,7 @@ This workflow orchestrates four policy skills:
 2. **Self-review checklist** (pr-policy)
 3. **Create PR** with full metadata:
    - Title: `[#issue] Component: Imperative description`
-   - Body: Changes, issue reference (`Closes #N`), testing, checklist
+   - Body: Changes section with `Closes #N` inline (creates Development sidebar link when targeting main; use `Part of #N` for non-main targets), testing, checklist
    - Apply labels (existing ones), set project (`--project`), set milestone (`--milestone`)
    - Assign user as reviewer (`--reviewer <username>`) and assignee (`--assignee "@me"`)
    - Size: Aim for < 200 lines changed
@@ -357,7 +357,6 @@ gh pr create --title "[#11] Auth: Set up OAuth2 client" \
 - OAuth2 client with PKCE support
 - Configuration via environment variables
 
-## Issue Reference
 Closes #11
 
 ## Testing

--- a/plugins/gh-sdlc/skills/pr-policy/SKILL.md
+++ b/plugins/gh-sdlc/skills/pr-policy/SKILL.md
@@ -68,7 +68,6 @@ gh pr create \
 ## Changes
 Brief technical summary of implementation approach.
 
-## Issue Reference
 Closes #issue-number
 
 ## Testing
@@ -86,6 +85,8 @@ Closes #issue-number
 ## Reviewer Notes
 Context for architectural decisions and tradeoffs.
 ```
+
+**The `Closes #N` line goes directly in the Changes section** — not in a separate heading. This creates the Development sidebar link automatically when the PR targets the default branch, giving a clean linked-issue appearance rather than a verbose "Issue Reference" section.
 
 ## PR Project Tracking
 
@@ -111,9 +112,21 @@ Every PR must have:
 - **Project**: Added to the active project board
 - **Milestone**: Same milestone as its linked issue
 - **Labels**: Matching issue labels
-- **Development link**: Issue linked via `Closes #N` in body (auto-links in GitHub's Development sidebar)
+- **Development link**: Issue linked in the Development sidebar (see below)
 - **Assignee**: The user (`--assignee "@me"`)
 - **Reviewer**: The user or designated reviewer
+
+### Development Sidebar Linking
+
+The Development sidebar shows linked issues with a status icon — this is the proper way to associate PRs with issues (not a body section).
+
+**When PR targets the default branch (main):**
+Include `Closes #N` in the PR body (inside the Changes section). GitHub automatically creates the Development sidebar link and will auto-close the issue on merge.
+
+**When PR targets a non-default branch (child → parent):**
+Closing keywords are **ignored** by GitHub when the PR doesn't target the default branch — no link is created and merging has no effect on issues. Instead, reference the issue with `Part of #N` or `For #N` in the body (no closing keyword). The Development sidebar link must be created manually via the GitHub UI, or accepted as absent for intermediate PRs.
+
+**Supported closing keywords:** `close`, `closes`, `closed`, `fix`, `fixes`, `fixed`, `resolve`, `resolves`, `resolved` (case-insensitive, optional colon).
 
 ## Checkbox Management
 


### PR DESCRIPTION
## Changes

The PR template previously had a dedicated `## Issue Reference` section:

```diff
  ## Changes
  Brief technical summary of implementation approach.

- ## Issue Reference
- Closes #issue-number
+ Closes #issue-number

  ## Testing
```

This produced a verbose body when GitHub's Development sidebar already shows the linked issue with a status icon. The `Closes #N` keyword is now embedded inline in the Changes section, which creates the Development sidebar link automatically.

Additionally, documented a critical GitHub behavior: **closing keywords are silently ignored when the PR targets a non-default branch**. For child PRs (targeting parent branches), no sidebar link or auto-close occurs. The workaround is to use `Part of #N` for reference and accept that intermediate PRs won't have the sidebar link.

### pr-policy updates
- Removed `## Issue Reference` from template, moved `Closes #N` inline
- Added "Development Sidebar Linking" section documenting default vs non-default branch behavior
- Listed all supported closing keywords (`close/closes/closed`, `fix/fixes/fixed`, `resolve/resolves/resolved`)

### gh-sdlc updates
- Phase 3 description references new linking approach with branch-target caveat
- Integrated example updated to match new template format

Closes #33

## Testing

- [x] PR template is consistent across pr-policy and gh-sdlc example
- [x] Non-default branch limitation documented with workaround
- [x] No contradictions between skills

## Checklist

- [x] Self-reviewed diff
- [x] No debugging artifacts
- [x] Commit history is clean