### PR TITLE
gh-35: remove bracket prefixes from child issue title convention

### DIFF
--- a/plugins/gh-sdlc/skills/gh-projects/SKILL.md
+++ b/plugins/gh-sdlc/skills/gh-projects/SKILL.md
@@ -302,7 +302,7 @@ gh pr create \
 
 ### Create Issue with Full Metadata
 ```bash
-gh issue create --title "[#1] Auth: Implement OAuth2 flow" \
+gh issue create --title "Auth: Implement OAuth2 flow" \
   --body "## Problem Statement
 OAuth2 needed for third-party auth.
 
@@ -372,7 +372,7 @@ When starting a new project, execute this setup sequence:
 4. **Create custom fields**: Status, Priority, Story Points, Due Date
 5. **Link repository**: `gh project link <number> --owner "@me" --repo <repo>`
 6. **Create parent issues**: High-level feature issues with Mermaid diagrams
-7. **Decompose into children**: Atomic child issues with `[#parent]` prefix
+7. **Decompose into children**: Atomic child issues linked via sub-issue API
 8. **Add all issues to project**: Bulk add with field assignments
 9. **Set field values**: Priority, status, iteration for each item
 

--- a/plugins/gh-sdlc/skills/gh-sdlc/SKILL.md
+++ b/plugins/gh-sdlc/skills/gh-sdlc/SKILL.md
@@ -204,7 +204,7 @@ This workflow orchestrates four policy skills:
    - Body: Problem statement, acceptance criteria, technical scope
    - Assign to user (`--assignee "@me"`)
 3. **Decompose** into child issues if complex:
-   - Each child: single concern, one PR, title prefixed `[#parent-id]`
+   - Each child: single concern, one PR, linked to parent via sub-issue API
    - Assign each child to user (`--assignee "@me"`)
    - Add Mermaid diagram to parent
    - **Link as sub-issues** via GraphQL API (not just title prefix)
@@ -324,10 +324,10 @@ graph TD
 \`\`\`" \
   --label "feature,P1-high" --milestone "v1.0"
 
-# Create child issues
-gh issue create --title "[#10] Auth: Set up OAuth2 client" --label "feature" --milestone "v1.0"
-gh issue create --title "[#10] Auth: Implement token refresh" --label "feature" --milestone "v1.0"
-gh issue create --title "[#10] Auth: Add session management" --label "feature" --milestone "v1.0"
+# Create child issues (linked via sub-issue API, not title prefix)
+gh issue create --title "Auth: Set up OAuth2 client" --label "feature" --milestone "v1.0"
+gh issue create --title "Auth: Implement token refresh" --label "feature" --milestone "v1.0"
+gh issue create --title "Auth: Add session management" --label "feature" --milestone "v1.0"
 
 # Add to project
 gh project item-add 1 --owner "@me" --url "$(gh issue view 10 --json url -q .url)"

--- a/plugins/gh-sdlc/skills/issue-policy/SKILL.md
+++ b/plugins/gh-sdlc/skills/issue-policy/SKILL.md
@@ -30,15 +30,15 @@ description: "GitHub issue creation and hierarchy standards (part of gh-sdlc). P
 ## Issue Title Format
 
 ```
-[#Parent-ID] Component: Imperative action description
+Component: Imperative action description
 ```
 
 **Examples:**
-- `[#1] Project: Initialize uv with discord.py dependencies`
-- `[#1] Bot: Implement core client with intents configuration`
-- `Commands: Add slash command registration system` (no parent)
+- `Project: Initialize uv with discord.py dependencies`
+- `Bot: Implement core client with intents configuration`
+- `Commands: Add slash command registration system`
 
-For child issues, ALWAYS prefix with `[#parent-id]`.
+Child issues use the same format — no bracket prefixes. Parent-child relationships are expressed via sub-issue linking (GraphQL API), not title conventions.
 
 ## Issue Body Structure
 
@@ -88,7 +88,7 @@ graph TD
 ### Child Issues
 - Address a SINGLE concern
 - Implementable in ONE pull request
-- Reference parent with `[#parent-id]` in title
+- Linked to parent via sub-issue API (not title prefix)
 - Each maps to exactly one PR
 
 ### Depth Limit
@@ -219,7 +219,7 @@ Always include assignment, labels, and milestone:
 
 ```bash
 gh issue create \
-  --title "[#parent] Component: Action description" \
+  --title "Component: Action description" \
   --body "..." \
   --label "feature" \
   --milestone "vX.Y" \
@@ -252,6 +252,6 @@ gh issue edit <number> --body "$UPDATED"
 
 - PR templates MUST require issue references
 - CI checks validate parent issues contain diagrams when children exist
-- CI checks verify child issues reference parents in titles
+- CI checks verify child issues are linked as sub-issues of their parent
 - Parent issues cannot close while children remain open
 - All child issues MUST be linked as sub-issues via the API


### PR DESCRIPTION
## Changes

Removes the `[#parent-id]` bracket prefix convention from child issue titles across all three affected skills. Parent-child relationships are now expressed exclusively via GitHub's sub-issue API (`addSubIssue` GraphQL mutation).

### issue-policy

```diff
  ## Issue Title Format
- [#Parent-ID] Component: Imperative action description
+ Component: Imperative action description

- For child issues, ALWAYS prefix with `[#parent-id]`.
+ Child issues use the same format — no bracket prefixes.
+ Parent-child relationships are expressed via sub-issue linking (GraphQL API), not title conventions.
```

Child issue rules, enforcement checks, and the example `gh issue create` command all updated accordingly.

### gh-sdlc

Phase 1 decomposition step and the integrated example's child issue creation commands updated:

```diff
  # Create child issues
- gh issue create --title "[#10] Auth: Set up OAuth2 client"
+ gh issue create --title "Auth: Set up OAuth2 client"
```

### gh-projects

Example issue title and setup workflow step updated to reference sub-issue API linking instead of title prefix.

Additionally, all 12 existing issues on GitHub that had bracket prefixes were edited to remove them.

Closes #35

## Testing

- [x] No remaining `[#parent` references in title format/convention sections
- [x] Mermaid diagram node syntax `[#N Title]` preserved (graph nodes, not titles)
- [x] PR title format `[#issue]` preserved (PRs use brackets, issues don't)
- [x] All 12 historical issues fixed on GitHub

## Checklist

- [x] Self-reviewed diff
- [x] No debugging artifacts
- [x] Commit history is clean