### PR TITLE
gh-37: use --body-file for all issue and PR body content

### DIFF
--- a/plugins/gh-sdlc/skills/gh-projects/SKILL.md
+++ b/plugins/gh-sdlc/skills/gh-projects/SKILL.md
@@ -291,7 +291,7 @@ When creating PRs, attach project metadata directly:
 ```bash
 gh pr create \
   --title "[#issue] Component: Description" \
-  --body "..." \
+  --body-file /tmp/pr-body.md \
   --project "Project Name" \
   --milestone "v1.0" \
   --label "feature" \
@@ -301,9 +301,12 @@ gh pr create \
 ## Issue Management with Project Context
 
 ### Create Issue with Full Metadata
+
+Always use `--body-file` for issue bodies to avoid shell corruption of markdown:
+
 ```bash
-gh issue create --title "Auth: Implement OAuth2 flow" \
-  --body "## Problem Statement
+cat > /tmp/issue-body.md <<'EOF'
+## Problem Statement
 OAuth2 needed for third-party auth.
 
 ## Acceptance Criteria
@@ -312,10 +315,16 @@ OAuth2 needed for third-party auth.
 - [ ] Tests pass
 
 ## Technical Scope
-**Files:** \`src/auth/\`, \`tests/test_auth.py\`" \
+**Files:** `src/auth/`, `tests/test_auth.py`
+EOF
+
+gh issue create --title "Auth: Implement OAuth2 flow" \
+  --body-file /tmp/issue-body.md \
   --label "feature,P1-high" \
   --milestone "v1.0" \
   --assignee "@me"
+
+rm /tmp/issue-body.md
 ```
 
 ### Add Issue to Project

--- a/plugins/gh-sdlc/skills/gh-sdlc/SKILL.md
+++ b/plugins/gh-sdlc/skills/gh-sdlc/SKILL.md
@@ -301,9 +301,9 @@ Given: `/gh-sdlc Add user authentication`
 
 **Step 1 — Plan (issue-policy + gh-projects):**
 ```bash
-# Create parent issue
-gh issue create --title "Auth: Implement user authentication system" \
-  --body "## Problem Statement
+# Write parent issue body to temp file (preserves markdown exactly)
+cat > /tmp/issue-body.md <<'EOF'
+## Problem Statement
 Application needs user authentication.
 
 ## Acceptance Criteria
@@ -313,16 +313,25 @@ Application needs user authentication.
 - [ ] Tests pass
 
 ## Technical Scope
-**Files:** \`src/auth/\`, \`tests/test_auth.py\`
+**Files:** `src/auth/`, `tests/test_auth.py`
+
 ---
+
 ## Sub-Issues
-\`\`\`mermaid
+```mermaid
 graph TD
     A[#10 User Authentication] --> B[#11 OAuth2 Client]
     A --> C[#12 Token Refresh]
     A --> D[#13 Session Management]
-\`\`\`" \
+```
+EOF
+
+# Create parent issue
+gh issue create --title "Auth: Implement user authentication system" \
+  --body-file /tmp/issue-body.md \
   --label "feature,P1-high" --milestone "v1.0"
+
+rm /tmp/issue-body.md
 
 # Create child issues (linked via sub-issue API, not title prefix)
 gh issue create --title "Auth: Set up OAuth2 client" --label "feature" --milestone "v1.0"
@@ -351,9 +360,9 @@ git commit -m "gh-11: add OAuth2 client tests"
 git rebase -i --autosquash origin/main
 git push --force-with-lease
 
-# Create PR with full metadata
-gh pr create --title "[#11] Auth: Set up OAuth2 client" \
-  --body "## Changes
+# Write PR body to temp file
+cat > /tmp/pr-body.md <<'EOF'
+## Changes
 - OAuth2 client with PKCE support
 - Configuration via environment variables
 
@@ -366,11 +375,18 @@ Closes #11
 ## Checklist
 - [ ] Self-reviewed diff
 - [ ] No debugging artifacts
-- [ ] Commit history is clean" \
+- [ ] Commit history is clean
+EOF
+
+# Create PR with full metadata
+gh pr create --title "[#11] Auth: Set up OAuth2 client" \
+  --body-file /tmp/pr-body.md \
   --label "feature" \
   --project "Project Name" \
   --milestone "v1.0" \
   --assignee "@me"
+
+rm /tmp/pr-body.md
 
 # Add PR to project board and set fields
 PR_URL=$(gh pr view 20 --json url -q .url)
@@ -378,9 +394,10 @@ ITEM_ID=$(gh project item-add 1 --owner "@me" --url "$PR_URL" --format json --jq
 # Set status to "In Review", priority matching issue, etc.
 
 # Tick issue acceptance criteria as satisfied
-BODY=$(gh issue view 11 --json body -q .body)
-UPDATED=$(echo "$BODY" | sed 's/- \[ \] OAuth2 client configured/- [x] OAuth2 client configured/')
-gh issue edit 11 --body "$UPDATED"
+gh issue view 11 --json body -q .body \
+  | sed 's/- \[ \] OAuth2 client configured/- [x] OAuth2 client configured/' \
+  > /tmp/updated-body.md
+gh issue edit 11 --body-file /tmp/updated-body.md
 ```
 
 **Step 4 — Merge (pr-policy + gh-projects):**

--- a/plugins/gh-sdlc/skills/issue-policy/SKILL.md
+++ b/plugins/gh-sdlc/skills/issue-policy/SKILL.md
@@ -215,15 +215,30 @@ Apply labels consistently:
 
 ## Issue Creation Command
 
-Always include assignment, labels, and milestone:
+Always use `--body-file` to pass issue bodies — never inline markdown in `--body "..."` because backticks, code blocks, and special characters get mangled by shell interpretation.
 
 ```bash
+# Write body to temp file (markdown is preserved exactly)
+cat > /tmp/issue-body.md <<'EOF'
+## Problem Statement
+Description of what needs to be done and why.
+
+## Acceptance Criteria
+- [ ] Criterion one
+- [ ] Criterion two
+
+## Technical Scope
+**Files:** `src/module/`, `tests/test_module.py`
+EOF
+
 gh issue create \
   --title "Component: Action description" \
-  --body "..." \
+  --body-file /tmp/issue-body.md \
   --label "feature" \
   --milestone "vX.Y" \
   --assignee "@me"
+
+rm /tmp/issue-body.md
 ```
 
 After creating child issues, ALWAYS link them as sub-issues of the parent (see "Issue Relationships" above).
@@ -235,10 +250,11 @@ After creating child issues, ALWAYS link them as sub-issues of the parent (see "
 ### How to tick checkboxes
 
 ```bash
-# Fetch current body, replace checkbox, update
-BODY=$(gh issue view <number> --json body -q .body)
-UPDATED=$(echo "$BODY" | sed 's/- \[ \] Criterion text/- [x] Criterion text/')
-gh issue edit <number> --body "$UPDATED"
+# Fetch current body, apply sed, write to temp file, update via --body-file
+gh issue view <number> --json body -q .body \
+  | sed 's/- \[ \] Criterion text/- [x] Criterion text/' \
+  > /tmp/updated-body.md
+gh issue edit <number> --body-file /tmp/updated-body.md
 ```
 
 ### Rules

--- a/plugins/gh-sdlc/skills/pr-policy/SKILL.md
+++ b/plugins/gh-sdlc/skills/pr-policy/SKILL.md
@@ -40,18 +40,36 @@ hotfix: Critical issue description
 
 ## PR Creation Command
 
-When creating a PR, apply all metadata in one command:
+When creating a PR, apply all metadata in one command. **Always use `--body-file`** to pass the PR body — never inline markdown in `--body "..."` because backticks, code blocks, and special characters get mangled by shell interpretation.
 
 ```bash
+# Write body to temp file (markdown is preserved exactly)
+cat > /tmp/pr-body.md <<'EOF'
+## Changes
+Brief technical summary.
+
+Closes #issue-number
+
+## Testing
+- [ ] Tests pass
+
+## Checklist
+- [ ] Self-reviewed diff
+EOF
+
 gh pr create \
   --title "[#issue] Component: Imperative description" \
-  --body "..." \
+  --body-file /tmp/pr-body.md \
   --label "existing-label" \
   --project "Project Name" \
   --milestone "vX.Y" \
   --reviewer "@me" \
   --assignee "@me"
+
+rm /tmp/pr-body.md
 ```
+
+**Why `--body-file`?** The `--body` flag passes through shell expansion, which corrupts backticks (`` ` ``), code fences (` ``` `), and `$` in markdown. Writing to a file first with a single-quoted heredoc (`<<'EOF'`) preserves content exactly.
 
 **Label rules:**
 - Use existing repository labels; rely on context to pick the right ones
@@ -134,28 +152,30 @@ Closing keywords are **ignored** by GitHub when the PR doesn't target the defaul
 
 ### How to tick checkboxes
 
-Fetch the current body, replace the checkbox text, and update:
+Fetch the current body, apply sed replacements, write to a temp file, and update via `--body-file`:
 
 ```bash
 # Tick a checkbox on a PR
-BODY=$(gh pr view <number> --json body -q .body)
-UPDATED=$(echo "$BODY" | sed 's/- \[ \] Unit tests added/- [x] Unit tests added/')
-gh pr edit <number> --body "$UPDATED"
+gh pr view <number> --json body -q .body \
+  | sed 's/- \[ \] Unit tests added/- [x] Unit tests added/' \
+  > /tmp/updated-body.md
+gh pr edit <number> --body-file /tmp/updated-body.md
 
 # Tick a checkbox on an issue
-BODY=$(gh issue view <number> --json body -q .body)
-UPDATED=$(echo "$BODY" | sed 's/- \[ \] Criterion one/- [x] Criterion one/')
-gh issue edit <number> --body "$UPDATED"
+gh issue view <number> --json body -q .body \
+  | sed 's/- \[ \] Criterion one/- [x] Criterion one/' \
+  > /tmp/updated-body.md
+gh issue edit <number> --body-file /tmp/updated-body.md
 ```
 
-**For multiple checkboxes**, chain the replacements:
+**For multiple checkboxes**, chain the sed replacements:
 
 ```bash
-BODY=$(gh pr view <number> --json body -q .body)
-UPDATED=$(echo "$BODY" \
+gh pr view <number> --json body -q .body \
   | sed 's/- \[ \] Unit tests added/- [x] Unit tests added/' \
-  | sed 's/- \[ \] Self-reviewed diff/- [x] Self-reviewed diff/')
-gh pr edit <number> --body "$UPDATED"
+  | sed 's/- \[ \] Self-reviewed diff/- [x] Self-reviewed diff/' \
+  > /tmp/updated-body.md
+gh pr edit <number> --body-file /tmp/updated-body.md
 ```
 
 **Rules:**


### PR DESCRIPTION
## Changes

Fixes markdown corruption in issue and PR bodies caused by shell expansion when using `--body "..."`. All four skills now use `--body-file` with a temp file pattern.

### The problem

Inline `--body` passes through shell expansion, which corrupts:
- Backticks (`` ` ``) — escaped to `\``
- Code fences (` ``` `) — broken or autolinked
- `$` characters — interpreted as variables

This produced broken rendering like issue #35 where diff blocks and inline code showed raw backslashes.

### The fix

```diff
- gh issue create --body "## Problem\n`code` and \`\`\`blocks\`\`\`"
+ cat > /tmp/issue-body.md <<'EOF'
+ ## Problem
+ `code` and ```blocks``` preserved exactly.
+ EOF
+ gh issue create --body-file /tmp/issue-body.md
```

### Skills updated

| Skill | What changed |
|-------|-------------|
| **pr-policy** | PR creation command, checkbox ticking (3 examples), added "Why `--body-file`?" explanation |
| **issue-policy** | Issue creation command with full body template, checkbox ticking |
| **gh-sdlc** | Integrated example: parent issue, PR creation, checkbox ticking (3 instances) |
| **gh-projects** | Issue creation example, PR metadata example |

Closes #37

## Testing

- [x] Issue #35 body fixed and rendering correctly
- [x] All `--body "..."` usage removed from creation/edit commands (only `--body "Description"` for trivial draft items remains)
- [x] Temp file pattern consistent: write with `<<'EOF'`, pass with `--body-file`, cleanup with `rm`

## Checklist

- [x] Self-reviewed diff
- [x] No debugging artifacts
- [x] Commit history is clean
