### PR TITLE
gh-47: unify PR title format to gh-issue prefix

### DIFF
--- a/plugins/gh-sdlc/README.md
+++ b/plugins/gh-sdlc/README.md
@@ -66,8 +66,9 @@ No bracket prefixes. Parent-child relationships use GitHub's sub-issue API, not 
 
 ### PR titles
 ```
-[#issue] Component: Imperative description
+gh-<issue>: <imperative description>
 ```
+Same format as commit messages — PR titles and commits are unified.
 
 ### Commit messages
 ```

--- a/plugins/gh-sdlc/agents/sdlc-shipper.md
+++ b/plugins/gh-sdlc/agents/sdlc-shipper.md
@@ -39,7 +39,7 @@ Only after the plan is solid, proceed to execution:
 5. **Track on project board** — Following gh-projects: add to project, set fields, apply labels, assign milestone
 6. **Branch** — Create feature branches mirroring issue hierarchy (sub-branches for sub-issues)
 7. **Commit** — Atomic commits following commit-policy: `gh-<issue>: <imperative summary>`
-8. **Open PR** — Following pr-policy: proper title `[#issue] Component: Description`, body with template, labels, project, milestone, reviewer
+8. **Open PR** — Following pr-policy: title `gh-<issue>: <imperative description>`, body with template, labels, project, milestone, reviewer
 9. **Merge** — Squash and merge (default), delete branch, update project board
 10. **Close** — Update issue status, check parent completion
 
@@ -52,7 +52,7 @@ Only after the plan is solid, proceed to execution:
 - Write public-facing content (issues, PRs, commits) for strangers — no session context leakage
 - Apply existing labels; only create new ones when nothing fits
 - Always assign issues and PRs to the user (`--assignee "@me"`)
-- Squash commit message format: `gh-<issue>: <imperative description> (#pr)`
+- PR title format: `gh-<issue>: <imperative description>` (same as commit messages — NO bracket prefix like `[#issue]`)
 - Link child issues as sub-issues of parent via GraphQL API
 - Create sub-branches for every sub-issue: `feature/<parent>/<child>-<description>`
 

--- a/plugins/gh-sdlc/skills/gh-projects/SKILL.md
+++ b/plugins/gh-sdlc/skills/gh-projects/SKILL.md
@@ -290,7 +290,7 @@ When creating PRs, attach project metadata directly:
 
 ```bash
 gh pr create \
-  --title "[#issue] Component: Description" \
+  --title "gh-<issue>: <imperative description>" \
   --body-file /tmp/pr-body.md \
   --project "Project Name" \
   --milestone "v1.0" \

--- a/plugins/gh-sdlc/skills/gh-sdlc/SKILL.md
+++ b/plugins/gh-sdlc/skills/gh-sdlc/SKILL.md
@@ -245,7 +245,7 @@ This workflow orchestrates four policy skills:
    ```
 2. **Self-review checklist** (pr-policy)
 3. **Create PR** with full metadata:
-   - Title: `[#issue] Component: Imperative description`
+   - Title: `gh-<issue>: <imperative description>` (same format as commits)
    - Body: Changes section with `Closes #N` inline (creates Development sidebar link when targeting main; use `Part of #N` for non-main targets), testing, checklist
    - Apply labels (existing ones), set project (`--project`), set milestone (`--milestone`)
    - Assign user as reviewer (`--reviewer <username>`) and assignee (`--assignee "@me"`)
@@ -379,7 +379,7 @@ Closes #11
 EOF
 
 # Create PR with full metadata
-gh pr create --title "[#11] Auth: Set up OAuth2 client" \
+gh pr create --title "gh-11: set up OAuth2 client" \
   --body-file /tmp/pr-body.md \
   --label "feature" \
   --project "Project Name" \

--- a/plugins/gh-sdlc/skills/pr-policy/SKILL.md
+++ b/plugins/gh-sdlc/skills/pr-policy/SKILL.md
@@ -24,18 +24,20 @@ description: "Pull request standards and merge strategies (part of gh-sdlc). Pro
 
 ## PR Title Format
 
+PR titles use the same format as commit messages — the issue reference prefix followed by an imperative description:
+
 ```
-[#issue] Component: Imperative description
+gh-<issue>: <imperative description>
 ```
 
 **Examples:**
-- `[#6] Project: Initialize uv with discord.py dependencies`
-- `[#8] Commands: Implement command registration system`
-- `[#15] Auth: Add OAuth2 token refresh logic`
+- `gh-6: initialize uv with discord.py dependencies`
+- `gh-8: implement command registration system`
+- `gh-15: add OAuth2 token refresh logic`
 
 **Hotfix format (no issue):**
 ```
-hotfix: Critical issue description
+hotfix: critical issue description
 ```
 
 ## PR Creation Command
@@ -58,7 +60,7 @@ Closes #issue-number
 EOF
 
 gh pr create \
-  --title "[#issue] Component: Imperative description" \
+  --title "gh-<issue>: <imperative description>" \
   --body-file /tmp/pr-body.md \
   --label "existing-label" \
   --project "Project Name" \


### PR DESCRIPTION
## Changes

The gh-sdlc plugin documented two different reference formats for the same artifact — PRs used `[#issue] Component: Description` while commits used `gh-<issue>: description`. This created cognitive overhead and made it harder to trace work across the pipeline.

This PR unifies both to `gh-<issue>: imperative description`, so PR titles and commit messages follow the same convention.

Closes - #47 

### Files changed

| File | Change |
|---|---|
| `plugins/gh-sdlc/README.md` | Update PR titles convention section |
| `plugins/gh-sdlc/agents/sdlc-shipper.md` | Fix Phase 9 description and Behavior rule |
| `plugins/gh-sdlc/skills/gh-projects/SKILL.md` | Fix PR create example title |
| `plugins/gh-sdlc/skills/gh-sdlc/SKILL.md` | Fix PR title in step 3 and create example |
| `plugins/gh-sdlc/skills/pr-policy/SKILL.md` | Update PR Title Format section, examples, and create command |

### Before / After

```diff
- [#6] Project: Initialize uv with discord.py dependencies
+ gh-6: initialize uv with discord.py dependencies

- gh pr create --title "[#11] Auth: Set up OAuth2 client"
+ gh pr create --title "gh-11: set up OAuth2 client"
```

## Testing

- [ ] All PR title examples in policy files use `gh-<issue>:` prefix
- [ ] No `[#issue]` bracket format remains in any PR title example
- [ ] README convention table is consistent with skill files

## Checklist

- [x] Self-reviewed diff
- [x] No functional code changes — documentation/policy only
- [x] Consistent across all 5 affected files
