### PR TITLE
gh-48: enforce pr suffix on all commits landing on main

### DIFF
--- a/plugins/gh-sdlc/README.md
+++ b/plugins/gh-sdlc/README.md
@@ -72,9 +72,11 @@ Same format as commit messages — PR titles and commits are unified.
 
 ### Commit messages
 ```
-gh-<issue>: <imperative summary>           # Issue-tracked (preferred)
+gh-<issue>: <imperative summary> (#pr)     # Issue-tracked on main (preferred)
+gh-<issue>: <imperative summary>           # Issue-tracked during development (PR not yet created)
 <type>(<scope>): <imperative summary>      # Untracked
 ```
+Every commit on main must include the `(#pr)` suffix referencing the PR it was merged through.
 
 ### Branch naming
 ```

--- a/plugins/gh-sdlc/agents/sdlc-shipper.md
+++ b/plugins/gh-sdlc/agents/sdlc-shipper.md
@@ -53,6 +53,7 @@ Only after the plan is solid, proceed to execution:
 - Apply existing labels; only create new ones when nothing fits
 - Always assign issues and PRs to the user (`--assignee "@me"`)
 - PR title format: `gh-<issue>: <imperative description>` (same as commit messages — NO bracket prefix like `[#issue]`)
+- Commit messages on main MUST include `(#pr)` suffix: `gh-<issue>: <imperative description> (#pr)`. For rebase merge, amend commits to add the PR number before merging. For squash merge, GitHub auto-appends it.
 - Link child issues as sub-issues of parent via GraphQL API
 - Create sub-branches for every sub-issue: `feature/<parent>/<child>-<description>`
 

--- a/plugins/gh-sdlc/skills/commit-policy/SKILL.md
+++ b/plugins/gh-sdlc/skills/commit-policy/SKILL.md
@@ -20,13 +20,14 @@ gh-<issue>: <imperative summary> (#pr)
 ```
 
 **Examples:**
-- `gh-18421: reject invalid UTF-8 in marshal string loader`
+- `gh-23: add database migration for user roles (#30)`
 - `gh-142579: avoid divmod crash on malformed _pylong.int (#435)`
-- `gh-23: add database migration for user roles`
+- `gh-18421: reject invalid UTF-8 in marshal string loader (#19012)`
 
 **Rules:**
 - Issue identifier comes FIRST
-- PR number appended in parentheses when applicable
+- PR number `(#pr)` MUST be appended to all commits that land on main — this is the final commit message after merge, not optional
+- During development on a feature branch, commits may omit `(#pr)` since the PR does not exist yet. The PR number is added at merge time (squash merge auto-appends it; for rebase merge, amend the commit message before merging)
 - Description body is RARELY needed — the issue tracker holds the context
 
 ### Case 2: Direct Commits (No Issue)

--- a/plugins/gh-sdlc/skills/gh-sdlc/SKILL.md
+++ b/plugins/gh-sdlc/skills/gh-sdlc/SKILL.md
@@ -402,10 +402,17 @@ gh issue edit 11 --body-file /tmp/updated-body.md
 
 **Step 4 — Merge (pr-policy + gh-projects):**
 ```bash
+# Before merge: append (#pr) to commit messages
+# For rebase merge, amend commits to include the PR number:
+git rebase -i HEAD~3  # reword each to append "(#20)"
+# e.g. "gh-11: add OAuth2 client configuration" → "gh-11: add OAuth2 client configuration (#20)"
+git push --force-with-lease
+
 # Rebase merge (default — clean atomic commits preserved on main)
 gh pr merge 20 --rebase --delete-branch
 
 # Squash merge ONLY if intermediary commits are broken
+# (squash merge auto-appends the PR number)
 # gh pr merge 20 --squash --delete-branch
 
 # Tick remaining checkboxes on PR and issue

--- a/plugins/gh-sdlc/skills/pr-policy/SKILL.md
+++ b/plugins/gh-sdlc/skills/pr-policy/SKILL.md
@@ -204,8 +204,13 @@ Use for:
 - Commit messages follow format guide
 - No "fix typo" or "address review" commits (use fixup workflow)
 - Linear history without merge commits
+- **Before merging:** amend all commit messages to include `(#pr)` suffix (e.g., `gh-11: add OAuth2 config (#20)`). This is mandatory — every commit on main must reference the PR it came from.
 
 ```bash
+# Amend commits to add (#pr), then force push
+git rebase -i HEAD~N  # reword each commit to append "(#<pr-number>)"
+git push --force-with-lease
+
 gh pr merge <number> --rebase --delete-branch
 ```
 
@@ -394,7 +399,7 @@ git revert <commit-hash>
 
 **Revert PR format:**
 ```
-Revert "[#23] Auth: Add OAuth2 support"
+Revert "gh-23: add OAuth2 support"
 
 This reverts commit a1b2c3d due to [reason].
 Root cause under investigation in #45.


### PR DESCRIPTION
## Changes

The `(#pr)` suffix in commit messages was mentioned in the format spec but treated as optional — most examples omitted it, and there were no instructions for *when* to add it. This PR makes it mandatory and explains the mechanics for both rebase and squash merge strategies.

Closes #48

### What changed

| File | Change |
|---|---|
| `plugins/gh-sdlc/README.md` | Commit format section: add `(#pr)` variant and mandatory note |
| `plugins/gh-sdlc/agents/sdlc-shipper.md` | Behavior: add explicit `(#pr)` suffix rule |
| `plugins/gh-sdlc/skills/commit-policy/SKILL.md` | All examples now show `(#pr)`; rules explain mandatory vs optional by context |
| `plugins/gh-sdlc/skills/gh-sdlc/SKILL.md` | Merge section: add pre-merge `git rebase -i` amend step |
| `plugins/gh-sdlc/skills/pr-policy/SKILL.md` | Self-review checklist: add pre-merge amend requirement; fix revert PR format |

### Before / After

```diff
- gh-23: add database migration for user roles
+ gh-23: add database migration for user roles (#30)

- # PR number appended in parentheses when applicable
+ # PR number (#pr) MUST be appended to all commits that land on main

# New pre-merge step in pr-policy and gh-sdlc:
+ git rebase -i HEAD~N  # reword each commit to append "(#<pr-number>)"
+ git push --force-with-lease
```

## Testing

- [ ] commit-policy examples all show `(#pr)` suffix
- [ ] commit-policy rules distinguish main vs feature branch context
- [ ] pr-policy and gh-sdlc merge sections show the rebase-amend step
- [ ] README commit format shows both variants with clear labels

## Checklist

- [x] Self-reviewed diff
- [x] Documentation-only changes
- [x] Consistent across all 5 affected files
