### PR TITLE
gh-53: add inline codeblock convention to `gh-sdlc` skill policies

### DIFF
--- a/plugins/gh-sdlc/agents/sdlc-shipper.md
+++ b/plugins/gh-sdlc/agents/sdlc-shipper.md
@@ -51,6 +51,7 @@ Only after the plan is solid, proceed to execution:
 - Use all preloaded skills (commit-policy, issue-policy, pr-policy, gh-projects, gh-sdlc)
 - Self-review before creating PRs
 - Write public-facing content (issues, PRs, commits) for strangers — no session context leakage
+- **Aggressively use inline codeblocks** in commit messages, issue titles, and PR titles for filenames (`` `README.md` ``), flags (`` `--body-file` ``), tool/package names (`` `ccgraft` ``), and directory paths (`` `plugins/` ``). See commit-policy for the full guide.
 - Apply existing labels; only create new ones when nothing fits
 - Always assign issues and PRs to the user (`--assignee "@me"`)
 - PR title format: `gh-<issue>: <imperative description>` (same as commit messages — NO bracket prefix like `[#issue]`)

--- a/plugins/gh-sdlc/skills/commit-policy/SKILL.md
+++ b/plugins/gh-sdlc/skills/commit-policy/SKILL.md
@@ -52,6 +52,30 @@ gh-<issue>: <imperative summary> (#pr)
 | Hard limit | 72 characters (optimized for `git log --oneline`) |
 | Capitalization | Lowercase after type/scope prefix |
 | Punctuation | No trailing period |
+| Inline codeblocks | Use backtick-wrapped codeblocks for filenames, flags, identifiers, and tool names in commit messages. See below. |
+
+## Inline Codeblock Usage
+
+**Aggressively use inline codeblocks** (backtick wrapping) in commit messages, issue titles, PR titles, and any public-facing text for:
+
+| What to wrap | Example |
+|-------------|---------|
+| Filenames and extensions | `` `README.md` ``, `` `.gitignore` ``, `` `pyproject.toml` `` |
+| CLI flags and options | `` `--body-file` ``, `` `--force-with-lease` ``, `` `--assignee` `` |
+| Directory paths | `` `plugins/` ``, `` `src/auth/` ``, `` `.claude/` `` |
+| Function/class/variable names | `` `export_session()` ``, `` `ConfigSnapshot` `` |
+| Plugin/tool/package names | `` `ccgraft` ``, `` `gh-sdlc` ``, `` `watchdog` `` |
+| Config keys and values | `` `SINGLE_SELECT` ``, `` `settings.json` `` |
+
+**Do NOT wrap:**
+- Generic English words that happen to also be technical terms (e.g., "session", "project", "branch" when used in plain prose)
+- Issue/PR numbers (`#42`, not `` `#42` ``)
+
+**Examples:**
+- `gh-37: use `--body-file` for all issue and PR body content (#38)` — flag wrapped
+- `gh-42: add `README.md` for `gh-sdlc` plugin (#44)` — filename and plugin name wrapped
+- `docs: add MIT license and `.gitignore` (#5)` — filename wrapped
+- `gh-23: migrate `gh-sdlc` skills to `plugins/` directory (#30)` — plugin name and directory wrapped
 
 ## Type Taxonomy
 

--- a/plugins/gh-sdlc/skills/issue-policy/SKILL.md
+++ b/plugins/gh-sdlc/skills/issue-policy/SKILL.md
@@ -34,9 +34,11 @@ Component: Imperative action description
 ```
 
 **Examples:**
-- `Project: Initialize uv with discord.py dependencies`
-- `Bot: Implement core client with intents configuration`
-- `Commands: Add slash command registration system`
+- ``Project: Initialize `uv` with `discord.py` dependencies``
+- ``Bot: Implement core client with intents configuration``
+- ``Commands: Add slash command registration system``
+
+Use inline codeblocks (backtick wrapping) for filenames, flags, tool/package names, and directory paths in titles. See commit-policy for the full codeblock usage guide.
 
 Child issues use the same format — no bracket prefixes. Parent-child relationships are expressed via sub-issue linking (GraphQL API), not title conventions.
 

--- a/plugins/gh-sdlc/skills/pr-policy/SKILL.md
+++ b/plugins/gh-sdlc/skills/pr-policy/SKILL.md
@@ -31,9 +31,11 @@ gh-<issue>: <imperative description>
 ```
 
 **Examples:**
-- `gh-6: initialize uv with discord.py dependencies`
-- `gh-8: implement command registration system`
-- `gh-15: add OAuth2 token refresh logic`
+- ``gh-6: initialize `uv` with `discord.py` dependencies``
+- ``gh-8: implement command registration system``
+- ``gh-15: add OAuth2 token refresh logic``
+
+Use inline codeblocks (backtick wrapping) for filenames, flags, tool/package names, and directory paths in titles. See commit-policy for the full codeblock usage guide.
 
 **Hotfix format (no issue):**
 ```


### PR DESCRIPTION
## Summary

Adds a formal inline codeblock usage convention to the `gh-sdlc` plugin so that commit messages, issue titles, and PR titles consistently use backtick wrapping for filenames, flags, tool/package names, and directory paths.

Before this change, the agent could produce:

> `gh-42: add README.md for gh-sdlc plugin`

After this change, it produces:

> ``gh-42: add `README.md` for `gh-sdlc` plugin``

## Changes

| File | Change |
|------|--------|
| `plugins/gh-sdlc/skills/commit-policy/SKILL.md` | Add "Inline Codeblock Usage" section: table of what to wrap (filenames, flags, paths, tool names), "Do NOT wrap" callout, and four worked examples |
| `plugins/gh-sdlc/skills/issue-policy/SKILL.md` | Update title examples to use backticks; add forward reference to `commit-policy` guide |
| `plugins/gh-sdlc/skills/pr-policy/SKILL.md` | Update title examples to use backticks; add forward reference to `commit-policy` guide |
| `plugins/gh-sdlc/agents/sdlc-shipper.md` | Add explicit inline codeblock rule with examples to the Behavior section |

## Diff Highlights

The core table added to `commit-policy/SKILL.md`:

| What to wrap | Example |
|-------------|---------|
| Filenames and extensions | `` `README.md` ``, `` `.gitignore` `` |
| CLI flags and options | `` `--body-file` ``, `` `--force-with-lease` `` |
| Directory paths | `` `plugins/` ``, `` `.claude/` `` |
| Function/class/variable names | `` `export_session()` ``, `` `ConfigSnapshot` `` |
| Plugin/tool/package names | `` `ccgraft` ``, `` `gh-sdlc` ``, `` `watchdog` `` |
| Config keys and values | `` `SINGLE_SELECT` ``, `` `settings.json` `` |

Closes #53

## Self-Review

- [x] All four files updated consistently
- [x] "Do NOT wrap" callout prevents over-application (generic English words, issue numbers)
- [x] Examples in `issue-policy` and `pr-policy` now demonstrate the convention
- [x] `sdlc-shipper.md` Behavior section propagates the rule to the agent
