### PR TITLE
gh-57: add `hypersaint` LLM-native repository architecture plugin

### DIFF
--- a/plugins/hypersaint/.claude-plugin/plugin.json
+++ b/plugins/hypersaint/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "hypersaint",
+  "description": "LLM-native repository architecture enforcing hypermodular directory structure and maximum strictness. Every directory is a self-describing atom with progressive disclosure, integrity hashes, and machine-readable manifests.",
+  "version": "1.0.0",
+  "author": {
+    "name": "Achyuth Jayadevan",
+    "email": "achyuth@jayadevan.in"
+  },
+  "repository": "https://github.com/Achxy/dotclaude",
+  "license": "MIT",
+  "keywords": [
+    "architecture",
+    "modularity",
+    "strictness",
+    "llm-native",
+    "repository-structure",
+    "progressive-disclosure",
+    "integrity"
+  ]
+}

--- a/plugins/hypersaint/README.md
+++ b/plugins/hypersaint/README.md
@@ -1,0 +1,99 @@
+# hypersaint
+
+A Claude Code plugin that enforces hypermodular, maximally strict repository architecture for codebases primarily or fully created and maintained by LLM agents.
+
+## Overview
+
+Hypersaint is a language-agnostic architecture framework built on two pillars:
+
+1. **Hyperstrictness** — Every configurable dial turned to maximum correctness. Tooling that enforces rather than suggests. Ceremony that eliminates ambiguity.
+2. **Hypermodularity** — Aggressively decomposed directory structure with progressive disclosure at every level. Self-describing atoms navigable without loading the full repo.
+
+Every decision optimizes for an agent that reads only what it needs, when it needs it, and never the whole codebase at once.
+
+## Skills
+
+| Skill | Purpose |
+|-------|---------|
+| **hypersaint** | Architecture orchestrator. Guides project setup, directory structure, manifest creation, CI integrity, and MCP server implementation following the Hypersaint framework. |
+
+## The Atom
+
+The atomic unit of work is a **directory** containing tightly related files for one concept:
+
+```
+any-directory/
+├── README.md          # Progressive disclosure docs (integrity hashes of siblings)
+├── index.toml         # Machine-readable manifest (exports, deps, integrity hashes)
+├── implementation     # Source files (< 200 lines each)
+└── tests/             # Unit + property-based tests (< 400 lines each)
+```
+
+- `README.md` hashes `index.toml`. `index.toml` hashes `README.md`. CI verifies both.
+- An agent navigates root → target by reading one manifest at each level.
+- No level requires loading its children to understand itself.
+
+## Reference Documents
+
+Loaded on-demand by the skill — never all at once.
+
+| Document | When to Load |
+|----------|-------------|
+| `philosophy.md` | Project setup, tool selection, dependency decisions |
+| `modularity.md` | Creating directory structure, organizing code |
+| `readme_format.md` | Writing or updating any `README.md` |
+| `index_toml_spec.md` | Creating or updating any `index.toml` |
+| `ci_integrity.md` | Setting up or modifying CI pipeline |
+| `mcp_server_spec.md` | Building the Hypersaint navigation MCP server |
+
+## Scripts
+
+| Script | Purpose | Usage |
+|--------|---------|-------|
+| `index_toml_generator.py` | Generate/update `index.toml` for a directory | `python scripts/index_toml_generator.py <target_dir>` |
+| `readme_hooks.py` | Top-down `README.md` update after changes | `python scripts/readme_hooks.py <root_dir> --changed <file1> <file2>` |
+| `verify_integrity.py` | CI integrity verification | `python scripts/verify_integrity.py . --strict` |
+
+## Assets
+
+| Asset | Purpose |
+|-------|---------|
+| `ci.yml` | GitHub Actions workflow template for integrity verification |
+
+## Key Conventions
+
+### Strictness
+- Maximum strictness on all linters and type checkers — no exceptions without commented justification
+- Exhaustive static typing — no `Any`, no untyped public API surface
+- Runtime validation (Pydantic, Zod, beartype) at every trust boundary
+- `__slots__` in Python, explicit interfaces in TypeScript
+- `__all__` in every Python file, explicit exports in TypeScript
+- Docstrings on every public symbol
+- Unit tests + property-based tests for every public function
+
+### Modularity
+- Directories are atoms — one concept per directory
+- Every directory has `README.md` + `index.toml` with cross-validated integrity hashes
+- DRY is supreme — shared utilities at the lowest common ancestor
+- Circular dependencies must be declared in both atoms with justification
+- Updating manifests is part of every change — CI enforces this
+
+## Requirements
+
+- Python 3.10+ (scripts use only stdlib)
+- A project where LLM agents are the primary maintainers
+
+## Installation
+
+Via the dotclaude marketplace:
+
+```
+/plugin marketplace add Achxy/dotclaude
+/plugin install hypersaint@dotclaude
+```
+
+Or load directly for development:
+
+```bash
+claude --plugin-dir ./plugins/hypersaint
+```

--- a/plugins/hypersaint/skills/hypersaint/SKILL.md
+++ b/plugins/hypersaint/skills/hypersaint/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: hypersaint
+description: >-
+  Enforces hypermodular, maximally strict repository architecture for codebases primarily or fully
+  created and maintained by LLM agents. Use this skill whenever creating a new project, repository,
+  or codebase from scratch, or when restructuring an existing one for LLM maintainability. Also
+  trigger when the user mentions "hypersaint", "hypermodular", "hyperstrict", "LLM-native repo",
+  "LLM-optimized codebase", "agent-maintained code", or asks for maximum strictness, maximum
+  correctness, or aggressive modularity. Use this skill even when the user asks for project setup,
+  scaffolding, or boilerplate — if the context suggests the project will be maintained by LLM agents,
+  Hypersaint is the correct architecture. This skill governs both the structural organization of code
+  (hypermodularity) and the quality/tooling standards (hyperstrictness). Always use this skill in
+  conjunction with language-specific best practices — Hypersaint is language-agnostic and the agent
+  must extrapolate its principles to whatever stack is in use.
+---
+
+# Hypersaint
+
+An architecture and ruleset for repositories that are primarily or fully created and maintained by
+LLM agents. Every decision optimizes for an agent that reads only what it needs, when it needs it,
+and never the whole codebase at once.
+
+**Two pillars:**
+1. **Hyperstrictness** — Every configurable dial turned to maximum correctness. Tooling that
+   enforces rather than suggests. Ceremony that eliminates ambiguity.
+2. **Hypermodularity** — Aggressively decomposed directory structure with progressive disclosure
+   at every level. Self-describing atoms navigable without loading the full repo.
+
+---
+
+## Quick Decision Guide
+
+| Situation | Action |
+|-----------|--------|
+| Starting a new project | Read [Philosophy](./references/philosophy.md), then [Modularity](./references/modularity.md) |
+| Setting up tooling/linting | Read [Philosophy → Tool Selection Doctrine](./references/philosophy.md) |
+| Creating directory structure | Read [Modularity](./references/modularity.md) |
+| Writing a README.md | Read [README Format Spec](./references/readme_format.md) |
+| Creating/updating index.toml | Read [index.toml Spec](./references/index_toml_spec.md), use `scripts/index_toml_generator.py` |
+| Adding CI pipeline | Use `assets/ci.yml` as template, read [CI Integrity](./references/ci_integrity.md) |
+| Updating READMEs after changes | Use `scripts/readme_hooks.py` |
+| Building the MCP navigation server | Read [MCP Server Spec](./references/mcp_server_spec.md) |
+
+---
+
+## Core Rules (Always in Context)
+
+These rules are non-negotiable. Every Hypersaint repository must satisfy all of them.
+
+### Strictness Rules
+
+1. **Every configurable strictness dial is at maximum.** Pyright strict mode. TypeScript `strict: true`
+   plus all pedantic flags. Ruff with all applicable rules enabled. No exceptions without explicit,
+   commented justification citing the specific error code.
+2. **Prefer tools that unify and enforce.** Ruff over flake8+isort+black. Biome over ESLint+Prettier.
+   Bun over Node. The tool that makes the wrong thing a hard error wins.
+3. **Static typing is exhaustive.** Every function has full parameter and return annotations. No `Any`.
+   No untyped public API surface. Runtime validation (Pydantic, Zod, beartype) at every trust boundary.
+4. **Every class declares its shape explicitly.** `__slots__` in Python. Explicit interfaces in TypeScript.
+   No implicit attribute creation.
+5. **Every module declares its public surface.** `__all__` in every Python file and `__init__.py`.
+   Explicit exports in TypeScript. No namespace pollution.
+6. **Every public symbol has a docstring.** Functions, classes, methods, modules. The docstring is the
+   contract the next agent reads instead of the implementation.
+7. **Tests are mandatory and layered.** Unit tests for known cases. Property-based tests (Hypothesis,
+   fast-check) for invariants. Both required for every public function.
+8. **Dependencies must be proven.** High adoption, active maintenance, trusted maintainers. Never
+   author security-sensitive code — wrap proven libraries so tightly that misuse is a type error.
+9. **Infrastructure is code.** Dev environment (Nix flakes), cloud resources (Terraform/Pulumi),
+   CI/CD, configuration (typed + validated at startup), containers (multi-stage, distroless).
+10. **The feedback loop is sacred.** Every change runs the full strictness suite. The agent loops
+    until it passes. Fast tools (Ruff, Biome, Pyright) are mandatory — speed enables tight loops.
+
+### Modularity Rules
+
+1. **Directories are atoms.** The atomic unit of work is a directory containing tightly related files
+   for one concept. The agent loads one atom, understands it fully, modifies it, and puts it back.
+2. **Every directory has a README.md.** Uses Hypersaint progressive disclosure format. Contains
+   integrity hashes of all sibling files (including index.toml, excluding itself).
+3. **Every directory has an index.toml.** Machine-readable manifest declaring exports, dependencies,
+   and integrity hashes of all sibling files (including README.md, excluding itself).
+4. **README and index.toml cross-validate.** README hashes index.toml. index.toml hashes README.md.
+   CI verifies both on every change. Mismatch is a hard failure.
+5. **Nesting has no depth limit but every level self-describes.** An agent navigates root → target
+   by reading one manifest at each level. No level requires loading its children to understand itself.
+6. **DRY is supreme.** Duplicated code is the most dangerous defect in an LLM-maintained repo. Shared
+   utilities live at semantically named paths under the lowest common ancestor of their consumers.
+7. **Circular dependencies must be declared.** In the index.toml of both involved atoms. Preferred
+   within the same parent directory. Always with justification.
+8. **Updating manifests is part of every change.** Modifying a file without updating the containing
+   directory's README.md and index.toml is an incomplete change. CI enforces this.
+
+---
+
+## Reference Documents
+
+Load these as needed — do not read all of them upfront.
+
+| Document | When to Load | Content |
+|----------|-------------|---------|
+| [Philosophy](./references/philosophy.md) | Project setup, tool selection, dependency decisions | Full Hypersaint philosophy: axioms, tool doctrine, code strictness, security, IaC, feedback loops |
+| [Modularity](./references/modularity.md) | Creating directory structure, organizing code | Atom structure, nesting rules, shared utilities, naming, progressive disclosure architecture |
+| [README Format](./references/readme_format.md) | Writing or updating any README.md | Progressive disclosure marker syntax, section types, FAQ format, integrity blocks |
+| [index.toml Spec](./references/index_toml_spec.md) | Creating or updating any index.toml | Full TOML schema, field definitions, hash format, dependency declarations |
+| [CI Integrity](./references/ci_integrity.md) | Setting up or modifying CI pipeline | Hash verification workflow, failure modes, integration with GitHub Actions |
+| [MCP Server Spec](./references/mcp_server_spec.md) | Building the Hypersaint navigation MCP server | Complete specification for the progressive disclosure MCP server |
+
+---
+
+## Scripts
+
+| Script | Purpose | Usage |
+|--------|---------|-------|
+| `scripts/index_toml_generator.py` | Generate/update index.toml for a directory | `python scripts/index_toml_generator.py <target_dir>` |
+| `scripts/readme_hooks.py` | Top-down README update after changes | `python scripts/readme_hooks.py <root_dir> --changed <file1> <file2> ...` |
+
+---
+
+## Assets
+
+| Asset | Purpose |
+|-------|---------|
+| `assets/ci.yml` | GitHub Actions workflow template for integrity verification |

--- a/plugins/hypersaint/skills/hypersaint/assets/ci.yml
+++ b/plugins/hypersaint/skills/hypersaint/assets/ci.yml
@@ -1,0 +1,74 @@
+# Hypersaint Integrity Verification CI
+#
+# This workflow verifies that all README.md and index.toml manifests
+# are in sync with the actual files in the repository. It runs the
+# full integrity check on every push and pull request.
+#
+# Failure means: someone (human or LLM) modified a file without
+# updating the containing directory's manifests. The change cannot
+# merge until manifests are corrected.
+#
+# Usage:
+#   Copy this file to .github/workflows/hypersaint-integrity.yml
+#   Ensure scripts/verify_integrity.py exists (see Hypersaint skill)
+
+name: Hypersaint Integrity
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+permissions:
+  contents: read
+
+jobs:
+  integrity:
+    name: Verify Manifest Integrity
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      # No pip dependencies needed — the integrity checker uses only stdlib
+      # (hashlib, tomllib, pathlib, re, os)
+
+      - name: Run integrity verification
+        run: |
+          python scripts/verify_integrity.py . --strict
+        env:
+          # Machine-readable output for the LLM agent's feedback loop
+          HYPERSAINT_OUTPUT: "machine"
+
+      - name: Summary on failure
+        if: failure()
+        run: |
+          echo "## Hypersaint Integrity Check Failed" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "One or more README.md or index.toml manifests are out of sync." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### How to fix" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Run the following commands locally:" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo '```bash' >> $GITHUB_STEP_SUMMARY
+          echo "# Update all affected READMEs and index.toml files" >> $GITHUB_STEP_SUMMARY
+          echo "python scripts/readme_hooks.py . --all" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "# Verify everything is clean" >> $GITHUB_STEP_SUMMARY
+          echo "python scripts/verify_integrity.py ." >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Or, to update only the directories affected by your changes:" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo '```bash' >> $GITHUB_STEP_SUMMARY
+          echo "python scripts/readme_hooks.py . --changed <your-changed-files>" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY

--- a/plugins/hypersaint/skills/hypersaint/references/ci_integrity.md
+++ b/plugins/hypersaint/skills/hypersaint/references/ci_integrity.md
@@ -1,0 +1,131 @@
+# Hypersaint CI Integrity Verification
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [What CI Checks](#what-ci-checks)
+3. [Failure Modes](#failure-modes)
+4. [Integration with GitHub Actions](#integration-with-github-actions)
+5. [Local Verification](#local-verification)
+
+---
+
+## Overview
+
+The Hypersaint CI integrity pipeline ensures that the manifest system (README.md + index.toml) is
+always in sync with the actual files. It runs on every push and pull request. Any mismatch is a
+hard failure — the change cannot be merged until manifests are updated.
+
+This is the enforcement mechanism for the rule: "Updating manifests is part of every change."
+
+---
+
+## What CI Checks
+
+The integrity check walks the entire repository tree and performs these verifications at every
+directory that contains an `index.toml`:
+
+### 1. index.toml Hash Accuracy
+
+For every entry in `[integrity]`:
+- Recompute the SHA-256 hash of the referenced file or directory.
+- Compare against the declared hash.
+- **FAIL** if any hash mismatches.
+
+### 2. index.toml Completeness
+
+- List all files and directories in the same directory as `index.toml` (excluding `index.toml`
+  itself, `.git`, `__pycache__`, `node_modules`, and other standard ignores).
+- **FAIL** if any file/directory exists but has no entry in `[integrity]`.
+- **FAIL** if any entry in `[integrity]` references a nonexistent file/directory.
+
+### 3. README.md Hash Accuracy
+
+- Parse the `<!-- @hs:integrity -->` block from README.md.
+- Recompute the SHA-256 hash of every referenced file (excluding README.md itself).
+- Compare against the declared hashes.
+- **FAIL** if any hash mismatches.
+
+### 4. README.md Completeness
+
+- Same completeness check as index.toml but for the README integrity block.
+- **FAIL** on missing or extra entries.
+
+### 5. Cross-Validation
+
+- The hash of `index.toml` as declared in README.md's integrity block must match the actual
+  `index.toml` file.
+- The hash of `README.md` as declared in index.toml's `[integrity]` table must match the actual
+  `README.md` file.
+- **FAIL** if either cross-reference is stale.
+
+### 6. Circular Dependency Symmetry
+
+- For every `[circular]` entry in every `index.toml`, verify that the referenced atom also
+  declares the reverse circular dependency.
+- **FAIL** on asymmetric circular declarations.
+
+### 7. Structural Completeness
+
+- Every directory in the repository (except root-level config dirs like `.git`, `.github`,
+  `node_modules`, `__pycache__`, `.mypy_cache`, `.ruff_cache`) must contain both `README.md`
+  and `index.toml`.
+- **FAIL** if any directory is missing either file.
+
+---
+
+## Failure Modes
+
+Each failure produces a machine-readable error message that the LLM agent can parse and act on.
+
+| Error Code | Message Format | Agent Action |
+|------------|---------------|--------------|
+| `HASH_MISMATCH` | `HASH_MISMATCH: {path} declared={declared} actual={actual}` | Recompute and update the manifest |
+| `MISSING_ENTRY` | `MISSING_ENTRY: {path} not in {manifest_file}` | Add the missing entry to the manifest |
+| `EXTRA_ENTRY` | `EXTRA_ENTRY: {path} in {manifest_file} but file does not exist` | Remove the stale entry |
+| `CROSS_VALIDATION` | `CROSS_VALIDATION: {file_a} hash of {file_b} is stale` | Update both manifests |
+| `CIRCULAR_ASYMMETRIC` | `CIRCULAR_ASYMMETRIC: {atom_a} declares circular with {atom_b} but not vice versa` | Add declaration to the other atom |
+| `MISSING_MANIFEST` | `MISSING_MANIFEST: {dir} missing {README.md|index.toml}` | Create the missing manifest |
+
+The error output is one error per line, parseable by the agent. The agent can loop: read errors →
+fix → re-run check → repeat until clean.
+
+---
+
+## Integration with GitHub Actions
+
+Use `assets/ci.yml` as the workflow template. The workflow:
+
+1. Checks out the repository.
+2. Sets up Python (the integrity check scripts are Python).
+3. Runs `scripts/verify_integrity.py` on the entire repo.
+4. Fails the job if any errors are reported.
+
+The workflow runs on:
+- Every push to any branch.
+- Every pull request targeting any branch.
+
+It is a **required status check** for merge — PRs cannot merge without passing integrity.
+
+---
+
+## Local Verification
+
+Developers (human or LLM) can run the integrity check locally before pushing:
+
+```bash
+python scripts/verify_integrity.py .
+```
+
+This produces the same error output as CI. The agent should run this after every change as part
+of its feedback loop (step 5 in the Agent Navigation Model described in the Modularity reference).
+
+For updating manifests automatically after changes:
+
+```bash
+# Update index.toml for a specific directory
+python scripts/index_toml_generator.py path/to/atom/
+
+# Update READMEs for all directories affected by a set of changed files
+python scripts/readme_hooks.py . --changed path/to/changed_file.py path/to/other_file.py
+```

--- a/plugins/hypersaint/skills/hypersaint/references/index_toml_spec.md
+++ b/plugins/hypersaint/skills/hypersaint/references/index_toml_spec.md
@@ -1,0 +1,356 @@
+# Hypersaint index.toml Specification
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Full Schema](#full-schema)
+3. [Field Definitions](#field-definitions)
+4. [Hash Computation](#hash-computation)
+5. [Dependency Declarations](#dependency-declarations)
+6. [Circular Dependencies](#circular-dependencies)
+7. [Description Field](#description-field)
+8. [Examples](#examples)
+9. [Validation Rules](#validation-rules)
+
+---
+
+## Overview
+
+`index.toml` is the machine-readable manifest present in every directory of a Hypersaint
+repository. It serves three purposes:
+
+1. **Integrity verification.** SHA-256 hashes of every sibling file (including README.md, excluding
+   itself) enable CI to detect when code changes without manifest updates.
+2. **Dependency declaration.** Explicit listing of what this atom imports and exports, enabling
+   dependency graph analysis without parsing code.
+3. **Navigation support.** The MCP server reads index.toml to provide structured directory
+   information to the agent.
+
+---
+
+## Full Schema
+
+```toml
+# Optional: 1-2 sentence description. RARE. See Description Field section.
+# description = "..."
+
+[exports]
+# Public symbols this atom exposes
+symbols = ["LoginHandler", "LoginConfig", "LoginError"]
+
+[dependencies]
+# Atoms this one imports from. Keys are import paths, values are lists of imported symbols.
+"src.features.auth.session" = ["create_session", "SessionToken"]
+"src.core.validation.email_format" = ["validate_email"]
+"src.infra.database.connection" = ["DatabaseConnection"]
+
+[circular]
+# Only present if circular dependencies exist. See Circular Dependencies section.
+# "src.features.auth.session" = "Session needs LoginError type for error propagation"
+
+[integrity]
+# SHA-256 hashes of every sibling file/directory, excluding index.toml itself.
+# README.md IS included here (cross-validation).
+# Subdirectories are hashed as the SHA-256 of their index.toml content.
+# Entries are sorted alphabetically.
+"README.md" = "a1b2c3d4e5f6..."
+"login.py" = "f6e5d4c3b2a1..."
+"test_login.py" = "1a2b3c4d5e6f..."
+"fixtures" = "6f5e4d3c2b1a..."
+
+[children]
+# Only present in non-leaf directories. Lists immediate child directories.
+# Keys are directory names, values are one-line descriptions.
+login = "User authentication via password and OAuth2"
+logout = "Session termination and token revocation"
+session = "Session creation, validation, and lifecycle management"
+```
+
+---
+
+## Field Definitions
+
+### `description` (Optional, Top-Level)
+
+A 1-2 sentence description of what this directory contains. This field is **rare and discouraged
+in most cases** — the README.md brief section is the primary description mechanism.
+
+Use `description` ONLY when something is non-obvious at the architectural level — for example:
+- Multiple sources of truth exist and the manifest needs to clarify which is canonical.
+- The directory's purpose is not inferable from its name and position in the tree.
+- A significant architectural decision affects how this directory should be interpreted.
+
+If the directory name, its position in the hierarchy, and its README brief adequately describe
+its purpose, omit this field.
+
+### `[exports]`
+
+The public API surface of this atom.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `symbols` | Array of strings | Yes | Every public symbol this atom exports. In Python, this mirrors `__all__`. In TypeScript, this mirrors the named exports. |
+
+### `[dependencies]`
+
+What this atom imports from other atoms.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| Keys | String (import path) | - | The full import path to the dependency atom |
+| Values | Array of strings | - | The specific symbols imported from that atom |
+
+If the atom has no external dependencies, this table is present but empty: `[dependencies]`.
+
+### `[circular]`
+
+Present ONLY if circular dependencies exist. See Circular Dependencies section below.
+
+### `[integrity]`
+
+SHA-256 hashes for integrity verification.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| Keys | String (filename or dirname) | - | Relative path to the sibling file or directory |
+| Values | String (hex SHA-256) | - | Lowercase hex-encoded SHA-256 hash |
+
+Rules:
+- `index.toml` itself is EXCLUDED (cannot hash itself).
+- `README.md` IS included (cross-validation).
+- All other files are included.
+- Subdirectories are represented by the SHA-256 hash of their `index.toml` file content.
+- Entries are sorted alphabetically by key.
+
+### `[children]`
+
+Present ONLY in non-leaf directories (directories that contain subdirectories).
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| Keys | String (directory name) | - | Name of the child directory |
+| Values | String | - | One-line description (< 80 chars) |
+
+---
+
+## Hash Computation
+
+All hashes are SHA-256, hex-encoded, lowercase, full 64-character digest.
+
+### File Hashing
+
+```python
+import hashlib
+
+def hash_file(path: str) -> str:
+    """Compute SHA-256 of a file's raw bytes."""
+    sha256 = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            sha256.update(chunk)
+    return sha256.hexdigest()
+```
+
+### Directory Hashing
+
+A directory's hash is the SHA-256 of its `index.toml` file content. This creates a Merkle-like
+chain: if any file inside a subdirectory changes → its `index.toml` hashes change → the parent's
+integrity hash for that subdirectory changes → the parent's `README.md` integrity block changes →
+the grandparent's integrity hash for the parent changes → and so on up to root.
+
+```python
+def hash_directory(path: str) -> str:
+    """Compute hash of a directory by hashing its index.toml."""
+    index_path = os.path.join(path, "index.toml")
+    return hash_file(index_path)
+```
+
+### Cross-Validation
+
+The cross-validation guarantee:
+
+1. `README.md` integrity block contains the hash of `index.toml`.
+2. `index.toml` `[integrity]` table contains the hash of `README.md`.
+3. If either file is modified, the other's hash reference becomes stale.
+4. CI recomputes all hashes and compares against both files.
+5. Any mismatch → hard failure. No merge.
+
+This means modifying ANY file in a directory requires updating BOTH `README.md` and `index.toml`.
+There is no shortcut.
+
+---
+
+## Dependency Declarations
+
+Dependencies are declared with full import paths and specific symbols.
+
+```toml
+[dependencies]
+"src.features.auth.session" = ["create_session", "SessionToken"]
+"src.core.types.result" = ["Result", "Ok", "Err"]
+```
+
+### Rules
+
+1. **Every import must be declared.** If the code in this atom imports from another atom, the
+   dependency must appear here. Import linting tooling (import-linter, eslint-plugin-import)
+   enforces this.
+2. **Symbols must be specific.** No wildcard imports. `["*"]` is never valid. List every symbol.
+3. **Transitive dependencies are not declared.** If A depends on B and B depends on C, A's
+   index.toml only lists B. Transitive deps are resolved by the MCP server's recursive navigation.
+4. **Standard library and third-party imports are not declared.** Only dependencies on other atoms
+   within the same repository are listed.
+
+---
+
+## Circular Dependencies
+
+Circular dependencies are not banned but must be declared, justified, and ideally contained.
+
+```toml
+[circular]
+"src.features.auth.session" = "Session creates LoginEvent which references LoginError type. Restructuring would require a shared error types atom that adds indirection without benefit since these two atoms are always modified together."
+```
+
+### Rules
+
+1. **Both sides must declare.** If A ↔ B is circular, both A's and B's index.toml must have a
+   `[circular]` entry naming the other.
+2. **Justification is mandatory.** The value is a string explaining WHY the cycle exists and WHY
+   restructuring is worse than the cycle.
+3. **Same-parent preferred (soft rule).** Circular dependencies between siblings (atoms under the
+   same parent directory) are tolerable. Cross-branch cycles are a strong signal of misplaced
+   responsibility and should be restructured unless the justification is compelling.
+4. **CI can enforce.** The integrity CI can optionally fail on undeclared circular dependencies
+   detected by import analysis.
+
+---
+
+## Description Field
+
+The optional top-level `description` field is governed by strict rules to prevent it from becoming
+a dumping ground.
+
+### When to Use
+
+- A report directory contains both PNG figures and the HTML/CSS source that generated them, and
+  it's unclear which is canonical.
+- A directory exists for historical reasons and its name doesn't reflect its current purpose.
+- An architectural constraint makes this directory's role non-obvious (e.g., it exists to break
+  a dependency cycle, not because it represents a domain concept).
+
+### When NOT to Use
+
+- The directory name clearly describes its purpose (`login/`, `date_format/`, `database/`).
+- The README.md brief section adequately explains the directory.
+- You're tempted to use it because "it doesn't hurt" — if it's not needed, its presence adds
+  noise that the agent must process.
+
+### Format
+
+```toml
+description = "Contains both generated PNG figures and the HTML/CSS templates used to create them. The PNGs in output/ are the canonical artifacts; the templates in src/ are the source of truth."
+```
+
+Maximum 2 sentences. If you need more, the README.md architecture section is the right place.
+
+---
+
+## Examples
+
+### Leaf Atom (No Children)
+
+```toml
+[exports]
+symbols = ["LoginHandler", "LoginConfig", "LoginError"]
+
+[dependencies]
+"src.features.auth.session" = ["create_session", "SessionToken"]
+"src.core.validation.email_format" = ["validate_email"]
+"src.infra.database.connection" = ["DatabaseConnection"]
+
+[integrity]
+"README.md" = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+"login.py" = "f6e5d4c3b2a1f6e5d4c3b2a1f6e5d4c3b2a1f6e5d4c3b2a1f6e5d4c3b2a1f6e5"
+"test_login.py" = "1a2b3c4d5e6f1a2b3c4d5e6f1a2b3c4d5e6f1a2b3c4d5e6f1a2b3c4d5e6f1a2b"
+```
+
+### Grouping Directory (Has Children)
+
+```toml
+[exports]
+symbols = []
+
+[dependencies]
+
+[children]
+login = "User authentication via password and OAuth2"
+logout = "Session termination and token revocation"
+session = "Session creation, validation, and lifecycle"
+password_reset = "Password reset flow via email token"
+
+[integrity]
+"README.md" = "b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3"
+"login" = "c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4"
+"logout" = "d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5"
+"session" = "e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6"
+"password_reset" = "f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1"
+```
+
+### Atom with Circular Dependency
+
+```toml
+[exports]
+symbols = ["LoginHandler", "LoginConfig", "LoginError"]
+
+[dependencies]
+"src.features.auth.session" = ["create_session", "SessionToken"]
+
+[circular]
+"src.features.auth.session" = "Session imports LoginError for error propagation. Both atoms model the auth flow and are always modified together."
+
+[integrity]
+"README.md" = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+"login.py" = "f6e5d4c3b2a1f6e5d4c3b2a1f6e5d4c3b2a1f6e5d4c3b2a1f6e5d4c3b2a1f6e5"
+"test_login.py" = "1a2b3c4d5e6f1a2b3c4d5e6f1a2b3c4d5e6f1a2b3c4d5e6f1a2b3c4d5e6f1a2b"
+```
+
+### Atom with Description (Rare)
+
+```toml
+description = "Contains generated PNG figures and the HTML/CSS source templates. PNGs in output/ are canonical; templates in src/ are source of truth."
+
+[exports]
+symbols = ["generate_figure", "FigureConfig"]
+
+[dependencies]
+"src.core.types.color" = ["ColorPalette"]
+
+[integrity]
+"README.md" = "1122334455667788990011223344556677889900112233445566778899001122"
+"figure_gen.py" = "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"
+"test_figure_gen.py" = "ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100"
+```
+
+---
+
+## Validation Rules
+
+CI and the MCP server validate index.toml against these rules:
+
+1. **Schema compliance.** All tables must be from the known set: `exports`, `dependencies`,
+   `circular`, `integrity`, `children`. Unknown tables are errors.
+2. **Hash accuracy.** Every hash in `[integrity]` must match the recomputed hash of the
+   corresponding file or directory. Mismatches are hard failures.
+3. **Completeness.** Every file and directory sibling to index.toml must have an entry in
+   `[integrity]`. Missing entries are hard failures. Extra entries (referencing nonexistent
+   files) are also hard failures.
+4. **Cross-validation.** The hash of `README.md` in `[integrity]` must match the actual file.
+   The hash of `index.toml` in README.md's integrity block must match the actual file.
+5. **Circular symmetry.** If atom A declares a circular dependency on atom B, atom B must also
+   declare a circular dependency on atom A. Asymmetric declarations are hard failures.
+6. **Export accuracy.** If the atom contains Python files, `[exports].symbols` should match the
+   union of all `__all__` declarations. (Tooling can enforce this; it is a recommended check,
+   not always a hard failure depending on language.)
+7. **Description length.** If `description` is present, it must be ≤ 2 sentences. Enforced by
+   counting sentence-ending punctuation (`.`, `!`, `?`).

--- a/plugins/hypersaint/skills/hypersaint/references/mcp_server_spec.md
+++ b/plugins/hypersaint/skills/hypersaint/references/mcp_server_spec.md
@@ -1,0 +1,623 @@
+# Hypersaint MCP Server Specification
+
+## For: A Coding Agent Building This Server
+
+This document specifies the Hypersaint Navigation MCP Server. You (the coding agent) will
+implement this as a Python MCP server using FastMCP. This document tells you what to build,
+how it should behave, and what the intended usage patterns are. It does NOT contain implementation
+code — that is your job.
+
+---
+
+## Table of Contents
+
+1. [Purpose and Role](#purpose-and-role)
+2. [Architecture Overview](#architecture-overview)
+3. [The Progressive Disclosure README Parser](#the-progressive-disclosure-readme-parser)
+4. [The index.toml Parser](#the-indextoml-parser)
+5. [Tool Definitions](#tool-definitions)
+6. [Recursive Navigation](#recursive-navigation)
+7. [Integrity Verification](#integrity-verification)
+8. [Error Handling](#error-handling)
+9. [Performance Requirements](#performance-requirements)
+10. [Configuration](#configuration)
+11. [Testing Requirements](#testing-requirements)
+12. [Deployment](#deployment)
+
+---
+
+## Purpose and Role
+
+The Hypersaint MCP server is the **primary navigation tool** for LLM agents working in a
+Hypersaint repository. Its job is to replace `ls`, `find`, `cat`, `grep`, and ad-hoc bash
+exploration with a structured, token-efficient interface that serves exactly the right level of
+detail at each step.
+
+Without this server, the agent would:
+- Run `ls -R` and load the entire directory tree (massive token waste).
+- `cat README.md` and load the entire progressive disclosure document (defeats the purpose).
+- `grep -r` across the repo to find relevant code (slow, noisy, context-flooding).
+
+With this server, the agent:
+- Calls `navigate("/")` and gets the top-level structure with one-line descriptions.
+- Calls `readme("/src/features/auth/login")` and gets ONLY the brief.
+- Calls `readme("/src/features/auth/login", section="gotchas")` and gets ONLY the gotchas.
+- Calls `readme("/src/features/auth/login", faq="3")` and gets ONLY that answer.
+- Calls `tree("/src/features")` and gets a recursive map with descriptions at every level.
+
+The token savings are orders of magnitude. More importantly, the agent receives *curated,
+high-relevance* information instead of raw filesystem dumps.
+
+---
+
+## Architecture Overview
+
+The server is a single Python process that:
+
+1. **On startup:** Receives the repository root path as configuration.
+2. **On each request:** Reads the relevant files from disk (index.toml, README.md) and returns
+   parsed, filtered results.
+3. **Caches parsed index.toml and README.md structures** in memory (invalidated on file mtime
+   change).
+
+There is NO database. No external dependencies beyond the MCP SDK and TOML/markdown parsing.
+The source of truth is always the filesystem.
+
+### Technology Stack
+
+- **Language:** Python 3.11+
+- **MCP Framework:** FastMCP (Python MCP SDK)
+- **TOML parsing:** `tomllib` (stdlib in 3.11+)
+- **README parsing:** Custom parser for `<!-- @hs:... -->` markers (see below)
+- **Hashing:** `hashlib` (stdlib)
+- **Transport:** stdio (for local use) and streamable HTTP (for remote)
+
+---
+
+## The Progressive Disclosure README Parser
+
+This is the core component. It parses Hypersaint README.md files into a structured tree that
+can be queried at any granularity.
+
+### Input
+
+A README.md file containing `<!-- @hs:... -->` markers as defined in the README Format Spec.
+
+### Parsing Rules
+
+1. **Identify all markers.** Scan for `<!-- @hs:DIRECTIVE` and `<!-- @/hs:DIRECTIVE -->` pairs.
+   Build a tree from the nesting structure.
+
+2. **Extract brief.** Content between `<!-- @hs:brief -->` and `<!-- @/hs:brief -->`.
+
+3. **Extract sections.** Content between `<!-- @hs:section id="ID" title="TITLE" -->` and
+   `<!-- @/hs:section -->`. Each section has an `id` and `title`.
+
+4. **Extract items within sections.** Content between `<!-- @hs:item id="ID" title="TITLE" -->`
+   and `<!-- @/hs:item -->`. Items are children of their containing section.
+
+5. **Extract FAQ entries.** Content between `<!-- @hs:faq id="ID" question="QUESTION" -->` and
+   `<!-- @/hs:faq -->`. FAQs are a special type of item within their containing section.
+
+6. **Extract integrity block.** Content between `<!-- @hs:integrity -->` and
+   `<!-- @/hs:integrity -->`. Parse the markdown table into a dictionary of filename → hash.
+
+### Output Data Structure
+
+The parser produces a tree:
+
+```
+ReadmeDocument:
+  brief: str                          # Raw markdown content of brief section
+  sections: dict[str, Section]        # id → Section
+  integrity: dict[str, str]           # filename → sha256 hash
+
+Section:
+  id: str
+  title: str
+  content: str                        # Raw markdown content (excluding nested items)
+  items: dict[str, Item]              # id → Item
+  faqs: dict[str, FAQ]                # id → FAQ (only in sections containing FAQs)
+
+Item:
+  id: str
+  title: str
+  content: str                        # Raw markdown content
+
+FAQ:
+  id: str
+  question: str
+  answer: str                         # Raw markdown content
+```
+
+### Edge Cases
+
+- **No markers at all:** Treat the entire file content as the brief. Return empty sections.
+- **Malformed markers:** Missing closing tag → error. The server should report which marker is
+  unclosed and at what line number.
+- **Nested items:** Items can theoretically contain sub-items. The parser should handle arbitrary
+  nesting depth by recursing on the same pattern.
+- **Content outside markers:** Any content not inside any marker is ignored by the parser (it
+  renders on GitHub but is not served by the MCP server). This allows decorative markdown that
+  only humans see.
+
+---
+
+## The index.toml Parser
+
+Simpler than the README parser. Uses `tomllib` to parse TOML and validates against the
+Hypersaint schema.
+
+### Output Data Structure
+
+```
+IndexManifest:
+  description: str | None             # Optional description
+  exports: list[str]                  # Symbol names
+  dependencies: dict[str, list[str]]  # import_path → [symbols]
+  circular: dict[str, str]            # import_path → justification
+  integrity: dict[str, str]           # filename → sha256 hash
+  children: dict[str, str]            # dirname → description
+```
+
+### Validation
+
+On parse, validate:
+- All required tables exist (`[exports]`, `[dependencies]`, `[integrity]`).
+- No unknown tables.
+- All values are the expected types.
+- If `[circular]` exists, values are non-empty strings (justifications).
+- If `[children]` exists, every listed directory actually exists on disk.
+
+Return validation errors as structured data, not exceptions.
+
+---
+
+## Tool Definitions
+
+The MCP server exposes the following tools. Each tool definition includes its name, description,
+parameters, and exact behavior.
+
+### `navigate`
+
+**Purpose:** Get the structure of a directory — what's in it, what each child does, and the
+atom's export/dependency information.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `path` | string | Yes | Path relative to repo root. Use `/` for root. |
+
+**Behavior:**
+1. Read `index.toml` at the given path.
+2. Read the `brief` section from `README.md` at the given path.
+3. Return a structured response containing:
+   - The brief text
+   - The exports list
+   - The dependencies dict
+   - The children dict (if non-leaf)
+   - The description (if present in index.toml)
+   - Whether circular dependencies exist (boolean flag — details loaded separately)
+
+**Response format:**
+Return as structured text. Example:
+
+```
+# /src/features/auth
+
+Handles all authentication and authorization flows.
+
+## Exports
+(none — this is a grouping directory)
+
+## Dependencies
+(none)
+
+## Children
+- login: User authentication via password and OAuth2
+- logout: Session termination and token revocation
+- session: Session creation, validation, and lifecycle
+- password_reset: Password reset flow via email token
+
+## Circular Dependencies
+None declared.
+```
+
+### `readme`
+
+**Purpose:** Read progressive disclosure sections from a README.md.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `path` | string | Yes | Path relative to repo root |
+| `level` | string | No | One of: `brief` (default), `full`. Controls how much is returned. |
+| `section` | string | No | Section ID to load (e.g., `architecture`, `gotchas`, `contracts`) |
+| `item` | string | No | Item ID to load (e.g., `contracts.login_handler`, `examples.oauth_login`) |
+| `faq` | string | No | FAQ ID to load (e.g., `1`, `2`, `3`). Returns the answer. |
+
+**Parameter precedence:** `faq` > `item` > `section` > `level`. If `faq` is provided, return
+only that FAQ answer. If `item` is provided, return only that item. And so on.
+
+**Special behavior for FAQ sections:**
+When `section="faq"` is requested (without a specific `faq` ID), return ONLY the question list,
+not the answers:
+
+```
+## FAQ
+
+1. Why does login() return a Result type instead of raising exceptions?
+2. Why is there a 100ms sleep after failed login?
+3. Why was a type: ignore set at line 47 in login.py?
+```
+
+The agent then requests a specific answer: `readme(path, faq="2")`.
+
+**When `level="brief"` (default):**
+Return only the brief section.
+
+**When `level="full"`:**
+Return the entire README content (all sections, all items, all FAQ answers). This is rare and
+should only be used when the agent needs to rewrite or comprehensively review the README.
+
+### `tree`
+
+**Purpose:** Get a recursive directory tree with descriptions at every level. This is the
+"zoomed out" view for understanding overall repo structure.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `path` | string | Yes | Path relative to repo root |
+| `depth` | integer | No | Maximum recursion depth. Default: 3. Use -1 for unlimited. |
+| `descriptions` | boolean | No | Include one-line descriptions from index.toml children tables. Default: true. |
+
+**Behavior:**
+1. Starting at the given path, recursively list child directories up to `depth` levels.
+2. For each directory, read its `index.toml` to get the `[children]` descriptions.
+3. If `descriptions` is true, include the one-line description next to each directory name.
+4. Format as an indented tree.
+
+**Response format:**
+
+```
+src/
+  features/ — Domain feature modules
+    auth/ — Authentication and authorization
+      login/ — User authentication via password and OAuth2
+      logout/ — Session termination and token revocation
+      session/ — Session creation, validation, and lifecycle
+    billing/ — Payment processing and invoicing
+      invoice/ — Invoice generation and management
+      payment/ — Payment gateway integration
+    format/ — Shared formatting utilities
+      date_format/ — Date/time formatting and parsing
+      currency_format/ — Currency display formatting
+  infra/ — Infrastructure layer
+    database/ — Database connection and query utilities
+    cache/ — Caching layer (Redis wrapper)
+  core/ — Repository-wide shared utilities
+    types/ — Common type definitions
+    errors/ — Error hierarchy and error handling
+    validation/ — Input validation utilities
+```
+
+### `deps`
+
+**Purpose:** Analyze dependency relationships for an atom or subtree.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `path` | string | Yes | Path relative to repo root |
+| `direction` | string | No | `outgoing` (what this atom depends on), `incoming` (what depends on this atom), or `both`. Default: `both`. |
+| `recursive` | boolean | No | If true, follow dependency chains transitively. Default: false. |
+
+**Behavior:**
+1. Read the target atom's `index.toml` for outgoing dependencies.
+2. For incoming dependencies: scan all `index.toml` files in the repo to find atoms that list
+   the target as a dependency. (This is cached — the server builds a reverse dependency index
+   on first call and invalidates on file changes.)
+3. If `recursive`, follow the chain: for outgoing, get deps of deps. For incoming, get dependents
+   of dependents. Mark cycle points.
+
+**Response format:**
+
+```
+# Dependencies for /src/features/auth/login
+
+## Outgoing (what login depends on)
+- src.features.auth.session → [create_session, SessionToken]
+- src.core.validation.email_format → [validate_email]
+- src.infra.database.connection → [DatabaseConnection]
+
+## Incoming (what depends on login)
+- src.features.auth.password_reset → [LoginError]
+- src.features.notifications.auth_events → [LoginEvent]
+
+## Circular Dependencies
+- src.features.auth.session ↔ src.features.auth.login
+  Reason: Session imports LoginError for error propagation.
+```
+
+### `integrity`
+
+**Purpose:** Verify integrity hashes for a directory or the entire repo.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `path` | string | Yes | Path relative to repo root. Use `/` for full repo. |
+| `fix` | boolean | No | If true, update hashes in-place instead of just reporting mismatches. Default: false. |
+
+**Behavior:**
+1. Walk the directory tree starting at `path`.
+2. For each directory with `index.toml` and `README.md`:
+   - Recompute all file hashes.
+   - Compare against declared hashes in both `index.toml` and `README.md`.
+   - Report mismatches.
+3. If `fix=true`: rewrite `index.toml` and `README.md` integrity blocks with correct hashes.
+   Also update parent directory hashes that reference the changed files.
+
+**Response format (check mode):**
+
+```
+# Integrity Check: /src/features/auth
+
+✓ /src/features/auth/login — All hashes match
+✗ /src/features/auth/session — 2 errors:
+  HASH_MISMATCH: session.py declared=abc123... actual=def456...
+  CROSS_VALIDATION: index.toml hash of README.md is stale
+✓ /src/features/auth/logout — All hashes match
+
+Summary: 1 of 3 atoms have integrity errors.
+```
+
+**Response format (fix mode):**
+
+```
+# Integrity Fix: /src/features/auth
+
+Fixed /src/features/auth/session/index.toml — updated 1 hash
+Fixed /src/features/auth/session/README.md — updated 1 hash
+Fixed /src/features/auth/index.toml — updated 1 child hash (session changed)
+Fixed /src/features/auth/README.md — updated 1 child hash (session changed)
+
+Summary: 4 files updated. Run integrity check to verify.
+```
+
+### `search`
+
+**Purpose:** Search across all manifests (index.toml and README briefs) for atoms matching a
+query. This is the agent's alternative to `grep -r` — it searches structured metadata instead
+of raw code.
+
+**Parameters:**
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `query` | string | Yes | Search terms |
+| `scope` | string | No | `exports` (search symbol names), `briefs` (search README briefs), `descriptions` (search index.toml descriptions and children descriptions), or `all`. Default: `all`. |
+
+**Behavior:**
+1. Load all index.toml and README briefs in the repo (cached).
+2. Search for the query string (case-insensitive substring match) across the selected scope.
+3. Return matching atoms with their path, matched field, and a snippet of the match context.
+
+**Response format:**
+
+```
+# Search results for "email"
+
+1. /src/core/validation/email_format
+   Match in: exports → ["validate_email", "EmailAddress"]
+   Brief: Validates and normalizes email addresses. Wraps the `email-validator` library.
+
+2. /src/features/auth/login
+   Match in: brief → "Email input validation"
+   Brief: Handles user authentication via username/password and OAuth2 flows.
+
+3. /src/features/format/email_format
+   Match in: children description → "Email address display formatting"
+   Brief: (load with readme for details)
+
+3 results found.
+```
+
+---
+
+## Recursive Navigation
+
+Several tools support recursive operation. The recursion model:
+
+### Tree Recursion (for `tree`)
+- Start at the given path.
+- Read `index.toml` `[children]` table.
+- For each child, recurse (up to `depth` limit).
+- Output is a formatted tree string.
+
+### Dependency Recursion (for `deps`)
+- Start at the given path's `index.toml`.
+- For each dependency, load that atom's `index.toml` and follow its dependencies.
+- Maintain a "visited" set to detect cycles. When a cycle is detected, mark it and stop recursing
+  that branch.
+- Output is a formatted dependency graph.
+
+### Integrity Recursion (for `integrity`)
+- Walk all directories from the given path downward.
+- At each directory, verify hashes.
+- Propagation: if a child directory's `index.toml` changes (because hashes were fixed), the
+  parent's hash of that child is now stale → fix the parent too → propagate upward.
+
+---
+
+## Error Handling
+
+Every tool returns structured errors. Never raise unhandled exceptions to the MCP client.
+
+### Error Response Format
+
+When a tool encounters an error, return it as structured text in the tool response:
+
+```
+ERROR: DIRECTORY_NOT_FOUND
+Path: /src/features/auth/nonexistent
+Message: The directory does not exist. Available children at /src/features/auth:
+  - login
+  - logout
+  - session
+  - password_reset
+```
+
+### Error Types
+
+| Error | When | Recovery Hint |
+|-------|------|---------------|
+| `DIRECTORY_NOT_FOUND` | Path doesn't exist | List available children at parent |
+| `MISSING_MANIFEST` | Directory exists but lacks index.toml or README.md | Suggest running index_toml_generator.py and creating README.md |
+| `MALFORMED_MANIFEST` | TOML parse error or schema violation | Show the specific parse error with line number |
+| `MALFORMED_README` | Unclosed or invalid `@hs:` markers | Show the specific marker error with line number |
+| `SECTION_NOT_FOUND` | Requested section/item/faq ID doesn't exist | List available section IDs |
+| `HASH_MISMATCH` | Integrity check found mismatches | Show declared vs actual hash |
+
+### Actionable Hints
+
+Every error must include enough information for the agent to self-correct. If a section isn't
+found, list the sections that DO exist. If a directory isn't found, list the directories that DO
+exist at the parent level. The agent should never receive an error and have to guess what to do
+next.
+
+---
+
+## Performance Requirements
+
+### Caching
+
+The server MUST cache:
+- Parsed `index.toml` structures (invalidated when file mtime changes).
+- Parsed `README.md` structures (invalidated when file mtime changes).
+- The reverse dependency index (invalidated when any `index.toml` changes).
+
+Cache invalidation is based on file mtime checks. On each request, check whether the relevant
+files have changed since last parse. If so, re-parse. If not, serve from cache.
+
+### Response Time
+
+- `navigate`: < 50ms for a single directory.
+- `readme`: < 50ms for a single section.
+- `tree`: < 200ms for depth=3 in a repo with 1000 directories.
+- `deps`: < 200ms for non-recursive, < 2s for recursive in a large repo.
+- `integrity`: Proportional to repo size. < 5s for full repo check on 1000 files.
+- `search`: < 500ms for full-repo search across all scopes.
+
+### Memory
+
+The full cache for a 1000-directory repo should fit in < 100MB. If the repo is larger, consider
+LRU eviction for README parses (they are the largest cached objects).
+
+---
+
+## Configuration
+
+The server accepts configuration via environment variables or a config file.
+
+### Environment Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `HYPERSAINT_REPO_ROOT` | Yes | - | Absolute path to the repository root |
+| `HYPERSAINT_CACHE_SIZE` | No | `1000` | Maximum number of cached README/index parses |
+| `HYPERSAINT_IGNORE_PATTERNS` | No | `.git,__pycache__,node_modules,.mypy_cache,.ruff_cache,.pytest_cache,dist,build` | Comma-separated directory names to ignore during tree/integrity walks |
+| `HYPERSAINT_TRANSPORT` | No | `stdio` | Transport mode: `stdio` or `http` |
+| `HYPERSAINT_HTTP_PORT` | No | `8765` | Port for HTTP transport |
+
+### Config File
+
+Alternatively, place a `.hypersaint.toml` at the repo root:
+
+```toml
+[server]
+cache_size = 1000
+transport = "stdio"
+http_port = 8765
+ignore_patterns = [".git", "__pycache__", "node_modules", ".mypy_cache", ".ruff_cache", ".pytest_cache", "dist", "build"]
+```
+
+Environment variables override config file values.
+
+---
+
+## Testing Requirements
+
+The MCP server itself must follow Hypersaint principles. That means:
+
+### Unit Tests
+
+- Parser tests: Verify correct parsing of README markers for every section type, including
+  edge cases (empty sections, deeply nested items, malformed markers).
+- index.toml parser tests: Verify correct parsing for all table types, including optional tables.
+- Hash computation tests: Verify correct SHA-256 for known files.
+- Tool response format tests: Verify each tool returns correctly formatted responses.
+
+### Property-Based Tests
+
+- For the README parser: generate random valid README structures and verify round-trip (parse →
+  serialize → parse produces identical structure).
+- For integrity checking: generate random directory trees, compute hashes, mutate one file,
+  verify the checker detects exactly the mutated file.
+
+### Integration Tests
+
+- Create a temporary Hypersaint-compliant directory structure.
+- Start the MCP server pointing at it.
+- Call each tool and verify responses match expectations.
+- Modify a file, verify integrity tool detects the change.
+- Run fix mode, verify the change is corrected.
+
+### Test Fixtures
+
+Include a `test_fixtures/` directory containing:
+- A minimal valid Hypersaint repository structure (3-4 atoms, 2 levels deep).
+- A deliberately broken structure (missing manifests, stale hashes, asymmetric circular deps)
+  for testing error detection.
+
+---
+
+## Deployment
+
+### Local (stdio)
+
+For use with Claude Code, Cursor, or any MCP client that supports stdio transport:
+
+```json
+{
+  "mcpServers": {
+    "hypersaint": {
+      "command": "python",
+      "args": ["-m", "hypersaint_mcp"],
+      "env": {
+        "HYPERSAINT_REPO_ROOT": "/path/to/repo"
+      }
+    }
+  }
+}
+```
+
+### Remote (HTTP)
+
+For use with remote MCP clients:
+
+```bash
+HYPERSAINT_REPO_ROOT=/path/to/repo HYPERSAINT_TRANSPORT=http python -m hypersaint_mcp
+```
+
+The server listens on the configured port and serves MCP over streamable HTTP.
+
+### As a Dev Dependency
+
+The server should be installable as a Python package:
+
+```bash
+pip install hypersaint-mcp
+```
+
+Or included in the project's Nix flake as a dev tool, consistent with Hypersaint's IaC principles.

--- a/plugins/hypersaint/skills/hypersaint/references/modularity.md
+++ b/plugins/hypersaint/skills/hypersaint/references/modularity.md
@@ -1,0 +1,428 @@
+# Hypersaint Modularity
+
+## Table of Contents
+
+1. [The Modularity Axiom](#the-modularity-axiom)
+2. [The Atom](#the-atom)
+3. [Directory Nesting](#directory-nesting)
+4. [Shared Utilities](#shared-utilities)
+5. [Dependency Management](#dependency-management)
+6. [The Manifest System](#the-manifest-system)
+7. [Progressive Disclosure Architecture](#progressive-disclosure-architecture)
+8. [Naming Conventions](#naming-conventions)
+9. [The Agent Navigation Model](#the-agent-navigation-model)
+10. [File Size and Complexity Limits](#file-size-and-complexity-limits)
+
+---
+
+## The Modularity Axiom
+
+Traditional codebases are organized around human ergonomics — files grouped by what makes sense to
+scroll through together, modules sized for a developer's mental model of a feature. This breaks
+down when the primary maintainer is an LLM that does not scroll, does not have persistent memory,
+and operates best when it can load a single small unit, understand it completely, modify it, and
+put it back without needing to comprehend the surrounding system.
+
+Hypersaint modularity resolves the tension between **navigability** (the LLM needs to find the
+right piece fast) and **isolation** (once it finds the piece, it should need nothing else to work
+on it).
+
+The key insight: in a hypermodular repo with full type annotations, docstrings, and `__all__`
+declarations, the agent working on module B does not need to read the *implementation* of a
+dependency — it reads the type signature and the docstring, which are the contract. DRY therefore
+*saves* context window rather than costing it, because a shared utility's contract is loaded once
+and is far smaller than duplicated implementations.
+
+---
+
+## The Atom
+
+The atom is the fundamental unit of work in a Hypersaint repository. It is a **directory**
+containing tightly related files that together represent one concept.
+
+### What Lives Inside an Atom
+
+```
+feature_name/
+├── README.md              # Progressive disclosure documentation (required)
+├── index.toml             # Machine-readable manifest (required)
+├── feature_name.py        # Implementation (one or more files)
+├── test_feature_name.py   # Unit + property-based tests (co-located, required)
+└── fixtures/              # Test fixtures, if needed (co-located)
+    └── sample_input.json
+```
+
+Rules for atom contents:
+
+1. **README.md** — Required. Uses Hypersaint progressive disclosure format. Contains integrity
+   hashes of every sibling file and directory (including index.toml, excluding itself).
+2. **index.toml** — Required. Machine-readable manifest. Contains integrity hashes of every sibling
+   file and directory (including README.md, excluding itself).
+3. **Implementation files** — The actual code. One concept per atom. If a file grows beyond what
+   represents a single cohesive concept, it should be split into a sub-atom (a subdirectory with
+   its own README.md and index.toml).
+4. **Test files** — Co-located. Always. The agent loading this atom has everything it needs to
+   understand and verify the code. Test file names mirror implementation file names with a `test_`
+   prefix (Python) or `.test.` infix (TypeScript) or `_test` suffix (Rust/Go).
+5. **Test fixtures** — Co-located inside the atom if they are specific to this atom. Shared test
+   infrastructure (factories, builders, mock servers) lives at a semantically named shared path
+   under the lowest common ancestor.
+6. **No configuration files at the atom level.** Tooling configuration (pyproject.toml, biome.json,
+   Cargo.toml) lives at the repository root or at the top-level project boundary. Atoms inherit
+   configuration. They do not override it.
+
+### What Does NOT Live Inside an Atom
+
+- Global configuration files (these live at root)
+- Documentation that spans multiple atoms (this lives at the parent level)
+- Build artifacts, cache files, generated code (these are gitignored)
+
+---
+
+## Directory Nesting
+
+Directories nest predictably following conventional domain decomposition, but decomposed to
+extremes. There is **no depth limit**. Each level self-describes via its README.md and index.toml.
+
+### Example Structure
+
+```
+project_root/
+├── README.md
+├── index.toml
+├── flake.nix
+├── pyproject.toml
+│
+├── src/
+│   ├── README.md
+│   ├── index.toml
+│   │
+│   ├── features/
+│   │   ├── README.md
+│   │   ├── index.toml
+│   │   │
+│   │   ├── auth/
+│   │   │   ├── README.md
+│   │   │   ├── index.toml
+│   │   │   │
+│   │   │   ├── login/
+│   │   │   │   ├── README.md
+│   │   │   │   ├── index.toml
+│   │   │   │   ├── login.py
+│   │   │   │   └── test_login.py
+│   │   │   │
+│   │   │   ├── logout/
+│   │   │   │   ├── README.md
+│   │   │   │   ├── index.toml
+│   │   │   │   ├── logout.py
+│   │   │   │   └── test_logout.py
+│   │   │   │
+│   │   │   └── session/
+│   │   │       ├── README.md
+│   │   │       ├── index.toml
+│   │   │       ├── session.py
+│   │   │       └── test_session.py
+│   │   │
+│   │   ├── billing/
+│   │   │   ├── README.md
+│   │   │   ├── index.toml
+│   │   │   │
+│   │   │   ├── invoice/
+│   │   │   │   └── ...
+│   │   │   └── payment/
+│   │   │       └── ...
+│   │   │
+│   │   └── format/                    # Shared utilities for features
+│   │       ├── README.md
+│   │       ├── index.toml
+│   │       │
+│   │       ├── date_format/
+│   │       │   ├── README.md
+│   │       │   ├── index.toml
+│   │       │   ├── date_format.py
+│   │       │   └── test_date_format.py
+│   │       │
+│   │       ├── currency_format/
+│   │       │   └── ...
+│   │       └── email_format/
+│   │           └── ...
+│   │
+│   ├── infra/
+│   │   ├── README.md
+│   │   ├── index.toml
+│   │   │
+│   │   ├── database/
+│   │   │   └── ...
+│   │   └── cache/
+│   │       └── ...
+│   │
+│   └── core/                          # Repository-wide shared utilities
+│       ├── README.md
+│       ├── index.toml
+│       │
+│       ├── types/
+│       │   └── ...
+│       ├── errors/
+│       │   └── ...
+│       └── validation/
+│           └── ...
+│
+├── deploy/
+│   ├── README.md
+│   ├── index.toml
+│   ├── terraform/
+│   │   └── ...
+│   └── docker/
+│       └── ...
+│
+└── ci/
+    ├── README.md
+    ├── index.toml
+    └── workflows/
+        └── ...
+```
+
+### Nesting Rules
+
+1. **Every directory at every level has README.md and index.toml.** No exceptions. Even if the
+   directory contains a single subdirectory, it has its own manifests.
+2. **Nesting follows domain decomposition.** `features/auth/login/` is three levels because the
+   domain is `features` → `auth` → `login`. Do not flatten this to `features/auth_login/` — depth
+   encodes semantic hierarchy that the agent uses for navigation.
+3. **Each level's README describes only its immediate contents.** The `features/` README describes
+   `auth/`, `billing/`, and `format/`. It does NOT describe `auth/login/` — that is `auth/`'s
+   README's job. This prevents redundancy and ensures each level is independently accurate.
+4. **No depth limit, but earn each level.** A new directory level is warranted when:
+   - The parent directory would otherwise contain more than ~7 atoms (cognitive overload threshold).
+   - The items being grouped share a semantic relationship that deserves a name.
+   - The grouping enables a shared utility path (see Shared Utilities below).
+5. **Leaf atoms should be small.** A leaf atom (one with no subdirectories) should ideally be
+   comprehensible by loading just its files — typically 1-3 implementation files, 1-3 test files.
+   If a leaf atom grows beyond this, decompose it into sub-atoms.
+
+---
+
+## Shared Utilities
+
+Shared utilities are code used by more than one atom. They follow the DRY principle, which is
+supreme in Hypersaint — duplicated code is the most dangerous defect in an LLM-maintained repo.
+
+### Placement Rules
+
+Shared utilities live at **semantically named paths** under the **lowest common ancestor** of
+their consumers.
+
+1. **Semantic naming is mandatory.** Never `_shared/`, `_common/`, `utils/`, or `helpers/`. The
+   directory name must describe what the utilities *do*. `format/` if they format things.
+   `validation/` if they validate things. `transform/` if they transform things. The name is the
+   first layer of progressive disclosure — an agent reading the parent directory's manifest
+   should understand what this group of utilities is for without loading any of them.
+
+2. **Lowest common ancestor placement.** If `features/auth/` and `features/billing/` both need
+   date formatting, the utility lives at `features/format/date_format/`. If `features/auth/` and
+   `infra/database/` both need it, it lives at `src/core/format/date_format/` (the root-level
+   shared utilities). The utility rises *exactly* to the level where all consumers can import it.
+
+3. **Promotion on second use.** A utility starts life inside the atom that first needs it. When a
+   second consumer appears, the utility is extracted to the appropriate shared path. This prevents
+   premature abstraction — utilities earn their shared status by being actually shared.
+
+4. **Shared utilities are atoms too.** They have README.md, index.toml, tests. They follow every
+   Hypersaint rule. They are not second-class citizens just because they are "utilities."
+
+### Example
+
+Two features need date formatting and currency formatting, but only one needs email formatting:
+
+```
+features/
+├── format/                        # Shared by multiple features
+│   ├── date_format/              # Used by auth + billing
+│   └── currency_format/          # Used by billing + reporting
+├── auth/
+│   ├── email_format/             # Used only by auth (not promoted yet)
+│   ├── login/
+│   └── session/
+└── billing/
+    ├── invoice/
+    └── payment/
+```
+
+If `notifications/` later needs email formatting too:
+
+```
+features/
+├── format/
+│   ├── date_format/
+│   ├── currency_format/
+│   └── email_format/            # Promoted: now used by auth + notifications
+├── auth/
+│   ├── login/
+│   └── session/
+├── billing/
+│   └── ...
+└── notifications/
+    └── ...
+```
+
+---
+
+## Dependency Management
+
+### DRY Is Supreme
+
+Duplicated code is the single most dangerous defect in an LLM-maintained repo. The agent fixes a
+bug in one copy and doesn't know the other copies exist. Every piece of logic exists exactly once.
+Every other module that needs it imports it from that single source.
+
+This is not at odds with atom isolation. In a Hypersaint repo where every public symbol has full
+type annotations and a docstring, the agent working on a consumer module reads the utility's
+*contract* (type signature + docstring) — not its implementation. The implementation need not be
+loaded into context unless the task is to modify the utility itself.
+
+### Dependency Direction
+
+There is no mandatory layered architecture (e.g., "domain never imports infrastructure"). Hypersaint
+does not impose a layer cake. However:
+
+1. **Dependency cycles must be declared.** If atom A depends on atom B and atom B depends on atom A,
+   both atoms' index.toml files must declare the circular dependency with a `[circular]` table
+   that names the other atom and provides a justification.
+
+2. **Cycles are preferred within the same parent.** Two siblings under the same parent directory
+   (e.g., `auth/login/` and `auth/session/`) having a circular dependency is tolerable and often
+   honest — they model a genuine bidirectional relationship. Cross-branch cycles
+   (e.g., `auth/login/` ↔ `billing/payment/`) are a strong signal of a misplaced responsibility
+   and should be restructured. This is a **soft rule** — if restructuring would create worse
+   problems (duplication, artificial indirection), the cycle can remain with justification.
+
+3. **Import linting is mandatory.** Use tooling to enforce dependency rules:
+   - Python: `import-linter` or `ruff` import rules
+   - TypeScript: `eslint-plugin-import` or Biome import rules
+   - Rust: `cargo-deny` for crate-level, module visibility for internal
+
+---
+
+## The Manifest System
+
+Every directory has two manifests that cross-validate each other.
+
+### README.md
+
+Human-and-agent-readable. Progressive disclosure format (see README Format Spec reference).
+Contains:
+- Brief description (always visible via MCP)
+- Architecture details (loaded on request)
+- Gotchas/traps (loaded on request)
+- Invariants/contracts (loaded on request, per-component)
+- Related atoms (loaded on request)
+- Usage examples (loaded on request, per-API)
+- Changelog / decision log (loaded on request)
+- FAQ with individually loadable answers (loaded on request, per-question)
+- Integrity hash block
+
+### index.toml
+
+Machine-readable. Contains:
+- File integrity hashes (including README.md hash)
+- Exports declaration
+- Dependency declarations
+- Circular dependency declarations (if any, with justification)
+- Optional 1-2 sentence description (rare, reserved for non-obvious cases)
+
+See the index.toml Spec reference for the full schema.
+
+### Cross-Validation
+
+README.md contains the hash of index.toml. index.toml contains the hash of README.md. They
+validate each other. If either is modified without updating the other, CI fails. This mechanical
+check makes manifest staleness impossible to miss.
+
+---
+
+## Progressive Disclosure Architecture
+
+README.md files use a marker-based progressive disclosure system that renders as valid GitHub
+markdown but is parsed by the Hypersaint MCP server into individually loadable sections.
+
+The full format specification is in the README Format Spec reference. The key architectural
+principles:
+
+1. **Brief is always returned.** Any query about a directory returns the brief section. This is
+   the agent's table of contents — enough to decide whether to load deeper.
+2. **Sections are loaded individually.** The agent requests "architecture" or "gotchas" or
+   "examples" by name. Only that section is returned.
+3. **FAQ questions are listed without answers.** The agent sees the questions, identifies which
+   is relevant to its task, and requests only that answer by ID.
+4. **Sub-sections within sections are independently loadable.** Contracts can be loaded per-component.
+   Examples can be loaded per-API. The granularity matches the agent's likely task scope.
+5. **Integrity is loadable but not auto-included.** Hash verification is a separate concern from
+   content navigation. The agent or CI requests the integrity block explicitly.
+
+---
+
+## Naming Conventions
+
+### Directories
+
+- **Lowercase with underscores.** `date_format/`, not `DateFormat/` or `date-format/`.
+- **Singular nouns for atoms.** `login/`, not `logins/`. The directory is the concept, not a
+  collection.
+- **Plural nouns for grouping directories.** `features/`, `types/`, `errors/`. The directory
+  contains multiple atoms.
+- **Semantically descriptive.** The name should tell the agent what is inside without opening
+  anything. `format/` over `utils/`. `validation/` over `helpers/`. `transform/` over `common/`.
+
+### Files
+
+- **Implementation files match the atom name.** `login/login.py`, `session/session.ts`.
+- **Test files mirror implementation files.** `login/test_login.py`, `session/session.test.ts`.
+- **One public concept per file.** A file may contain private helpers for the public concept, but
+  it exports exactly one primary thing (a class, a function group, a schema).
+
+### Imports
+
+- **Absolute imports from the project root.** `from src.features.auth.login.login import LoginHandler`.
+  Never relative imports that navigate upward (`from ...format import ...`). Absolute imports are
+  greppable and unambiguous.
+- **Import the symbol, not the module** (where language conventions permit). `from module import Class`
+  over `import module` in Python. Named imports in TypeScript/JavaScript.
+
+---
+
+## The Agent Navigation Model
+
+An agent working on a Hypersaint repository follows this pattern:
+
+1. **Start at root.** Read root index.toml (via MCP: `navigate("/")`). Get top-level structure.
+2. **Navigate to area of interest.** Based on the task, identify which top-level directory to
+   enter. Read its brief (via MCP: `readme("/src/features", level="brief")`).
+3. **Drill down.** Repeat: read the next level's brief, identify the target atom.
+4. **Load the atom.** Read the target atom's brief. If needed, request architecture, contracts,
+   examples, or FAQ answers for specific questions relevant to the task.
+5. **Work.** Load the implementation and test files. Make changes.
+6. **Update manifests.** Update the atom's README.md (hashes, and any content changes if the
+   atom's public API changed) and index.toml. Propagate hash updates to parent directories
+   (the parent's README and index.toml hash their children, which now changed).
+7. **Verify.** Run integrity check. Run strictness suite on the atom. Loop until pass.
+8. **Commit.** The change is complete.
+
+The MCP server is the primary navigation tool. The agent should not use `find`, `ls -R`, or `grep`
+to navigate the structure — it uses the MCP server, which returns exactly the right level of detail
+at each step and prevents accidental context overload.
+
+---
+
+## File Size and Complexity Limits
+
+These are guidelines, not hard limits. The principle is: if an agent would need to scroll, the file
+is too long.
+
+- **Implementation files:** Aim for < 200 lines. If a file exceeds this, consider whether it
+  represents more than one concept and should be decomposed into sub-atoms.
+- **Test files:** May be longer than implementation files (test code is often more verbose). Aim
+  for < 400 lines. If longer, split by test category (unit vs property vs integration).
+- **README.md:** No limit — the progressive disclosure system means the agent never loads the
+  whole thing at once. Write as comprehensively as needed.
+- **index.toml:** Typically < 50 lines. If longer, the directory has too many direct children
+  and should be further decomposed.

--- a/plugins/hypersaint/skills/hypersaint/references/philosophy.md
+++ b/plugins/hypersaint/skills/hypersaint/references/philosophy.md
@@ -1,0 +1,380 @@
+# Hypersaint Philosophy
+
+## Table of Contents
+
+1. [The Foundational Axiom](#the-foundational-axiom)
+2. [Tool Selection Doctrine](#tool-selection-doctrine)
+3. [Code-Level Strictness](#code-level-strictness)
+4. [Dependency Philosophy](#dependency-philosophy)
+5. [Security Posture](#security-posture)
+6. [Infrastructure as Code](#infrastructure-as-code)
+7. [The Feedback Loop](#the-feedback-loop)
+8. [What Hypersaint Is Not](#what-hypersaint-is-not)
+
+---
+
+## The Foundational Axiom
+
+An LLM's time is free. Tedium has zero cost. Therefore, every trade-off that humans historically
+resolved in favor of "good enough" or "pragmatic" gets resolved instead in favor of maximum
+correctness, maximum explicitness, and maximum strictness. Developer experience is not a concern.
+Shipping speed is not a concern. The only concern is that the codebase is so rigorously correct,
+so self-describing, and so tightly constrained that failure becomes structurally difficult rather
+than behaviorally avoided.
+
+A new LLM agent — dropped in cold, with no conversation history, reading a single file — should be
+able to understand that file completely, modify it correctly, and have the toolchain catch any
+mistake before it propagates.
+
+The codebase is the specification. The specification is the codebase. There is no gap between
+intent and implementation because every intent is encoded as a type, a contract, a test, a
+validation, or an assertion. Ambiguity is a defect.
+
+---
+
+## Tool Selection Doctrine
+
+When multiple tools exist for a job, Hypersaint selects by the following hierarchy. These criteria
+are ordered by priority — a tool that satisfies criterion 1 beats one that satisfies only 2-4.
+
+### 1. Strictness by Default
+
+The tool that ships with the harshest defaults wins. A tool you have to configure *down* from
+strictness is preferred over one you configure *up* toward it. If two tools are equal in strictness,
+the one with fewer configuration options wins — fewer knobs means fewer opportunities for the agent
+to weaken the contract.
+
+### 2. Unification
+
+One tool that replaces three is preferred. Fewer moving parts, fewer config files, fewer sources of
+truth, fewer things to version and keep in sync. A single tool that lints, formats, and sorts imports
+is superior to three tools that do those things separately — even if each individual tool is slightly
+better at its narrow job.
+
+### 3. Modernity
+
+The tool built with knowledge of its predecessors' mistakes, written in a fast compiled language,
+designed for today's workflows. Rust-based tooling over legacy Python-based tooling. This is not
+novelty bias — it is a recognition that newer tools encode lessons from the failures of older ones.
+
+### 4. Enforcement over Convention
+
+A tool that makes the wrong thing a hard error is preferred over one that makes the wrong thing a
+warning. A tool that makes the wrong thing a warning is preferred over one that relies on
+documentation. If it can be a type error, it must not be a runtime error. If it can be a lint error,
+it must not be a code review comment.
+
+### Concrete Examples
+
+These examples illustrate the pattern. The agent must extrapolate to any domain — the specific
+tools change over time; the selection principle does not.
+
+| Domain | Hypersaint Choice | Over | Why |
+|--------|------------------|------|-----|
+| Python linting + formatting | Ruff | flake8+isort+black | Unified, fast, strict defaults |
+| Python type checking | Pyright (strict mode) | mypy, pyflakes | Stricter, faster, better inference |
+| JS/TS linting + formatting | Biome | ESLint+Prettier | Unified, fast, strict defaults |
+| JS/TS runtime | Bun | Node+npm | Unified (runtime+pm+bundler), faster |
+| Static typing | TypeScript | JavaScript | Enforcement over convention |
+| Systems language | Rust | C++ | Memory safety by default, stricter compiler |
+| Desktop apps | Tauri | Electron | Smaller, more secure, Rust core |
+| Mail server | Stalwart | Dovecot+Postfix | Unified, modern, Rust |
+| Dev environment | Nix flakes | Manual install / Homebrew | Reproducible, declarative, versioned |
+| IaC | Terraform/Pulumi | Manual cloud console | Versioned, reviewable, reproducible |
+| Container base | Distroless/scratch | Ubuntu/Alpine | Minimal attack surface |
+
+When encountering a domain not listed here, apply the four criteria in order. If uncertain between
+two tools that seem equivalent, **ask the user** — Hypersaint is opinionated, but the user's
+context (existing team familiarity, deployment constraints) can override tool selection when there
+is genuine parity.
+
+---
+
+## Code-Level Strictness
+
+Every configurable dial in the language and its toolchain gets turned to its strictest defensible
+setting. What follows are principles with examples — not an exhaustive list. The agent must
+extrapolate the underlying principle to any language.
+
+### Explicit Shape Declaration
+
+Every class, struct, or data type declares its own shape explicitly in the file where it is defined.
+
+- **Python:** Every class defines `__slots__`. This forces explicit attribute declaration, prevents
+  typo-based silent attribute creation, reduces memory usage, and critically — tells any agent
+  reading the file exactly what attributes exist without chasing inheritance.
+- **TypeScript:** Every interface is explicit. No `any`, no implicit index signatures, no `Record`
+  where a proper interface belongs.
+- **Rust:** Structs derive only what they need. No blanket `#[derive(Clone, Debug, Default)]` unless
+  every trait is actually used.
+
+### Namespace Hygiene
+
+Nothing leaks into a namespace by accident. The public surface of every module is a conscious,
+documented decision.
+
+- **Python:** Every module declares `__all__`. Every package's `__init__.py` declares `__all__`.
+  Every re-export is intentional. `from module import *` in consuming code is acceptable *only*
+  because `__all__` guarantees it imports exactly what was intended.
+- **TypeScript:** Explicit `export` on every public symbol. No default exports (they create naming
+  ambiguity). Barrel files (`index.ts`) declare explicit re-exports.
+- **Rust:** `pub(crate)` over `pub` where full public visibility isn't needed. Explicit `pub use`
+  re-exports in `mod.rs` / `lib.rs`.
+
+### Exhaustive Static Typing
+
+The strictest mode the type checker supports is always enabled.
+
+- **Python:** Pyright in strict mode (`"typeCheckingMode": "strict"`). Every function has full
+  parameter and return type annotations. No `Any` unless interfacing with an untyped external
+  library — and then, the `Any` is immediately narrowed at the boundary via a typed wrapper.
+  No `# type: ignore` without a specific error code and a comment explaining why. Every
+  `# type: ignore[specific-code]` is tracked as technical debt.
+- **TypeScript:** `strict: true` plus: `noUncheckedIndexedAccess`, `exactOptionalPropertyTypes`,
+  `noPropertyAccessFromIndexSignature`, `noFallthroughCasesInSwitch`, `forceConsistentCasingInFileNames`.
+  No `as any`. No `@ts-ignore` — use `@ts-expect-error` with explanation if absolutely necessary.
+- **Rust:** `#![deny(clippy::all, clippy::pedantic)]`. Address or explicitly allow every warning
+  with justification.
+
+### Runtime Validation at Trust Boundaries
+
+Static types are a compile-time promise. Runtime validation is the proof. Data crossing a trust
+boundary — user input, API responses, file reads, environment variables, database results,
+deserialized payloads — is validated at the boundary with a schema.
+
+- **Python:** Pydantic models for structured data. beartype decorators for function signatures
+  where Pydantic is too heavy. `pydantic.SecretStr` for sensitive values.
+- **TypeScript:** Zod schemas at every trust boundary. Parse, don't validate — `z.parse()` returns
+  typed data, not a boolean.
+- **Rust:** `serde` with `#[serde(deny_unknown_fields)]`. Newtype wrappers for validated primitives
+  (e.g., `EmailAddress(String)` that validates on construction).
+
+### Error Handling
+
+Prefer explicit error-as-value patterns over thrown exceptions where the language supports it.
+
+- **Rust:** `Result<T, E>` everywhere. `?` operator for propagation. Custom error types via
+  `thiserror`. Never `unwrap()` in library code — only in tests or with a comment explaining why
+  the panic is logically impossible.
+- **TypeScript:** Discriminated union result types or a `Result<T, E>` library. `try/catch` only
+  at the outermost boundary (HTTP handler, CLI entry point). Inner code returns errors as values.
+- **Python:** Exceptions are idiomatic, so: never bare `except`. Always catch the narrowest
+  exception type. Document every exception a function can raise in its docstring. Consider
+  `returns` library for Result-type patterns in critical paths.
+
+### Documentation as Contract
+
+Every public symbol has a docstring or doc comment. This is not optional and it is not decoration.
+The docstring is the contract that tells the next agent what this unit does, what it accepts, what
+it returns, what it raises, and what invariants it maintains — without reading the implementation.
+
+Format:
+- **Python:** Google-style docstrings. `Args:`, `Returns:`, `Raises:` sections mandatory for any
+  function with parameters. One-line summary mandatory for everything.
+- **TypeScript:** TSDoc (`/** */`). `@param`, `@returns`, `@throws` tags mandatory.
+- **Rust:** `///` doc comments. Examples in doc comments that compile and run via `cargo test`.
+
+### Testing
+
+Tests are mandatory, layered, and co-located with the code they test.
+
+- **Unit tests:** Every public function has at least one. Test the contract (inputs → outputs),
+  not the implementation.
+- **Property-based tests:** Every public function with a meaningful invariant has a property test.
+  Hypothesis (Python), fast-check (TypeScript), proptest (Rust). The property test expresses the
+  invariant; unit tests are specific instances of it.
+- **Contracts and invariants:** Assert preconditions at function entry. Assert postconditions before
+  return. These are not "defensive programming" — they are executable specifications that catch
+  violations at the earliest possible moment.
+
+### Formatting
+
+Formatting is never manual and never debatable. The tool decides. The agent runs the formatter.
+
+- **Python:** Ruff format. Line length configured once in `pyproject.toml`. Never overridden.
+- **TypeScript:** Biome format. Configured once in `biome.json`.
+- **Rust:** `rustfmt` with `edition = 2021`. No overrides.
+
+---
+
+## Dependency Philosophy
+
+### Use Dependencies Aggressively — But Only Proven Ones
+
+A "proven" dependency satisfies ALL of:
+- **High adoption:** Significant GitHub stars, download counts, production usage.
+- **Active maintenance:** Recent commits, responsive to issues, regular releases.
+- **Trusted provenance:** Backed by a known organization (Microsoft, Google, Mozilla, etc.) or a
+  well-known maintainer with a track record.
+- **Type-safe:** Ships with types (TypeScript declarations, py.typed marker, etc.). An untyped
+  dependency cannot satisfy Hypersaint's static typing requirements.
+
+If a battle-tested library exists, use it. Do not rewrite what the ecosystem has already solved
+and hardened through years of production use and security audits.
+
+### Author the Least Code Possible
+
+The safest code is code you didn't write. Prefer a thin, strictly typed wrapper around a proven
+library over a bespoke implementation. The wrapper's job is:
+
+1. Constrain the library's API surface to only the correct usage patterns for your domain.
+2. Add type narrowing so that misuse is caught at the type level.
+3. Add runtime validation at the boundary between your code and the library.
+4. Provide a stable internal API so the library can be swapped without touching consumers.
+
+### Minimal but Not Ascetic
+
+This is not a "zero dependency" philosophy. It is a "zero unjustified dependency" philosophy. Every
+dependency earns its place by being better, more tested, and more maintained than what you would
+write. When a dependency doesn't exist or isn't trustworthy for a task, then and only then do you
+author it — to the same standard as everything else in the codebase.
+
+When authoring is necessary, prefer writing the smallest possible utility and placing it at a
+semantically named shared path (see Modularity) where other atoms can import it.
+
+---
+
+## Security Posture
+
+Security in Hypersaint is not a feature — it is a structural property. The codebase is designed
+so that insecure code is *inexpressible*, not merely discouraged.
+
+### Never Author Security-Sensitive Code
+
+Authentication, cryptography, session management, token handling, CSRF protection, input
+sanitization, password hashing, key derivation — these are always delegated to established
+libraries. The agent NEVER writes custom implementations of any security-critical algorithm.
+
+### Wrappers Must Make Misuse Impossible
+
+The wrapper around a security library must constrain the API so that:
+- The insecure configuration is a type error, not a runtime option.
+- Default parameters are the secure choice. There is no "easy insecure mode."
+- Sensitive values use dedicated types (`SecretStr`, `SecretBytes`) that prevent accidental
+  logging or serialization.
+- If a user can XSS themselves through your interface, that is a failure — regardless of how
+  unlikely or trivial the vector is.
+
+### Trust Boundaries Are Explicit
+
+Every point where data enters the system from an external source is marked as a trust boundary.
+Data at trust boundaries is:
+1. Validated against a schema (Pydantic, Zod, serde).
+2. Sanitized for the context it will be used in (HTML escaping, SQL parameterization, etc.).
+3. Typed as "validated" after passing through the boundary — so consuming code can distinguish
+   validated from unvalidated data at the type level.
+
+---
+
+## Infrastructure as Code — Full Extent
+
+Nothing is manual. Nothing lives in a dashboard. Nothing depends on "just SSH in and..." or "click
+this button in the console." The entire system — from the developer's local shell to production
+deployment — is described in versioned, reviewable, reproducible files.
+
+### Development Environment
+
+Nix flakes define the complete development shell. Every tool, every dependency, every version is
+pinned and reproducible. A new contributor (human or LLM) runs one command and gets the exact
+environment. No "install these six things and hope the versions align."
+
+```
+flake.nix           # Pin all dev tools and system dependencies
+flake.lock          # Locked dependency graph
+.envrc              # direnv integration for automatic shell activation
+```
+
+### Infrastructure
+
+Terraform, Pulumi, or equivalent. Cloud resources are code. DNS is code. Secrets management is
+code (sealed/encrypted, never plaintext in the repo). If it exists in production, it exists as a
+versioned file in the repository.
+
+### CI/CD
+
+Pipelines are code in the repository. The full strictness suite runs on every change:
+1. Formatting check (Ruff format / Biome format)
+2. Linting (Ruff / Biome lint)
+3. Static type checking (Pyright / tsc)
+4. Unit tests
+5. Property-based tests
+6. Security scanning (dependency audit, SAST)
+7. Integrity verification (Hypersaint hash checks — see CI Integrity reference)
+
+The LLM's feedback loop depends on this: it makes a change, pushes, and gets machine-readable
+pass/fail output it can self-correct from. Every failure message must be specific and actionable.
+
+### Configuration
+
+Application config is typed and validated at startup, not read from loose env vars with string
+fallbacks.
+
+- **Python:** Pydantic `BaseSettings` with validators. Missing or malformed config → crash at
+  startup with a clear error. Never silently fall back to a default for a required value.
+- **TypeScript:** Zod schema parsing `process.env` at startup. Invalid config → thrown error
+  with the specific field and expected type.
+- **Rust:** Typed config struct deserialized at startup via `serde`. Missing fields → panic with
+  field name and expected type.
+
+Environment-specific overrides (dev, staging, prod) are structured files (TOML, JSON), not ad-hoc
+env vars. Each override file is validated against the same schema.
+
+### Containerization
+
+- Multi-stage builds. Build stage installs dependencies and compiles. Final stage copies only
+  artifacts.
+- Minimal final images. Distroless (Google) or scratch where possible. Alpine only if distroless
+  is genuinely impractical.
+- No shell in production images unless explicitly required and justified.
+- Health checks defined in the Dockerfile or compose file, not assumed.
+- Non-root user by default. `USER nobody` or equivalent.
+
+---
+
+## The Feedback Loop
+
+All of the above converges on one operational principle: **the LLM self-corrects from
+machine-readable toolchain output.**
+
+Every change the agent makes passes through the full strictness suite. If it fails, the error
+messages are specific, actionable, and parseable. The agent loops — fix, re-run, fix, re-run —
+until the suite passes. Overkill is not in the vocabulary. The cost of running the suite ten
+times is zero. The cost of shipping a defect is nonzero.
+
+This is why tool selection matters so much. Fast tools (Ruff: milliseconds, Biome: milliseconds,
+Pyright: seconds) give the agent tight feedback loops. Slow legacy tools (pylint: many seconds,
+ESLint: seconds per file) make the loop expensive. Speed is not a developer-experience luxury —
+it is an agent-efficiency requirement.
+
+The ideal loop:
+1. Agent modifies an atom (one or a few files in one directory).
+2. Agent runs the strictness suite on that atom (< 5 seconds).
+3. On failure: agent reads the error, modifies, re-runs. Repeat until pass.
+4. Agent updates README.md and index.toml for the containing directory.
+5. Agent runs integrity check (hash verification).
+6. On pass: change is complete. Commit.
+
+---
+
+## What Hypersaint Is Not
+
+**It is not about functional programming purity.** Side effects are fine. Mutation is fine. IO is
+fine. What matters is that side effects are explicit, typed, contained, and tested — not that they
+don't exist.
+
+**It is not about developer experience.** Verbose? Good. Ceremonial? Good. Requires writing
+`__slots__` on every class, `__all__` on every module, docstrings on every function, property tests
+for every invariant? Good. The maintainer doesn't get bored or frustrated.
+
+**It is not about shipping fast.** It is about shipping *correctly*. The first version may take
+longer. Every version after that is faster because the codebase is so well-constrained that changes
+are safe and isolated.
+
+**It is not language-specific.** The examples skew toward Python, TypeScript, and Rust because those
+are common LLM-maintained stacks. The philosophy applies to any language. The agent's job is to find
+the Hypersaint-aligned tools and patterns for whatever environment it encounters.
+
+**It is not a framework.** Hypersaint is an architecture and a ruleset. It does not impose a
+directory naming scheme beyond the structural rules (README.md, index.toml). It does not require
+a specific web framework, database, or deployment target. It constrains *how* code is organized
+and maintained, not *what* the code does.

--- a/plugins/hypersaint/skills/hypersaint/references/readme_format.md
+++ b/plugins/hypersaint/skills/hypersaint/references/readme_format.md
@@ -1,0 +1,523 @@
+# Hypersaint README Format Specification
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Marker Syntax](#marker-syntax)
+3. [Section Types](#section-types)
+4. [Disclosure Levels](#disclosure-levels)
+5. [FAQ Format](#faq-format)
+6. [Sub-Sections](#sub-sections)
+7. [Integrity Block](#integrity-block)
+8. [Full Example](#full-example)
+9. [Rendering Behavior](#rendering-behavior)
+10. [Authoring Rules](#authoring-rules)
+
+---
+
+## Overview
+
+Every README.md in a Hypersaint repository is simultaneously:
+
+1. **Valid GitHub-flavored markdown** — renders correctly on GitHub, GitLab, etc.
+2. **A progressive disclosure document** — parsed by the Hypersaint MCP server into individually
+   loadable sections.
+
+The progressive disclosure is implemented via HTML comment markers that are invisible in rendered
+markdown but structurally meaningful to the MCP server.
+
+The fundamental principle: an agent should NEVER load the entire README. It loads the brief, decides
+what else it needs, and loads only those sections. The README can be arbitrarily comprehensive
+because the cost of comprehensiveness is zero when disclosure is progressive.
+
+---
+
+## Marker Syntax
+
+All markers are HTML comments with the `@hs:` prefix:
+
+```
+<!-- @hs:DIRECTIVE [arguments] -->
+content
+<!-- @/hs:DIRECTIVE -->
+```
+
+Markers are always paired (opening + closing) except for self-closing markers:
+
+```
+<!-- @hs:DIRECTIVE [arguments] /-->
+```
+
+### Escaping
+
+Content within markers is standard markdown. No special escaping is needed. The MCP server extracts
+raw content between markers and returns it as-is.
+
+### Nesting
+
+Markers can be nested. A section can contain sub-sections. A FAQ section contains question markers,
+each containing an answer marker. The nesting is parsed into a tree by the MCP server.
+
+---
+
+## Section Types
+
+### Brief
+
+The brief is the outermost mandatory section. It is always returned by the MCP server when a
+directory is queried without specifying a section. It is the "table of contents" for the atom.
+
+```markdown
+<!-- @hs:brief -->
+# Login Handler
+
+Handles user authentication via username/password and OAuth2 flows.
+
+**Exports:** `LoginHandler`, `LoginConfig`, `LoginError`
+
+**Files:**
+- `login.py` — Core login logic and session creation
+- `test_login.py` — Unit and property-based tests
+- `fixtures/` — Test credentials and mock OAuth responses
+
+**Dependencies:**
+- `src.features.auth.session` — Session creation after successful login
+- `src.core.validation.email_format` — Email input validation
+- `src.infra.database.connection` — User credential lookup
+<!-- @/hs:brief -->
+```
+
+The brief MUST include:
+- A one-line description of what this atom is
+- Exports (public symbols)
+- File listing with one-line descriptions
+- Dependencies (what this atom imports from)
+
+The brief SHOULD be < 30 lines. It is loaded on every navigation step, so brevity matters.
+
+### Architecture
+
+Deeper structural detail about how the atom works internally.
+
+```markdown
+<!-- @hs:section id="architecture" title="Architecture" -->
+## Architecture
+
+The login handler implements a two-phase authentication flow:
+
+1. **Credential validation phase:** Validates input format (email via `email_format`, password
+   strength via internal `_validate_password_strength`), then checks credentials against the
+   database via the `connection` dependency.
+
+2. **Session creation phase:** On successful credential validation, delegates to `session.create()`
+   which returns a `SessionToken`. The handler never creates sessions directly — this separation
+   ensures session policy changes don't require login code changes.
+
+The OAuth2 flow follows the same two-phase pattern but replaces credential validation with token
+exchange via the OAuth provider.
+
+**Data flow:**
+```
+UserInput → validate_input() → check_credentials() → session.create() → SessionToken
+UserInput → validate_input() → exchange_oauth_token() → session.create() → SessionToken
+```
+<!-- @/hs:section -->
+```
+
+### Gotchas / Traps
+
+Things that look wrong but are intentional, or things that look like they should work but don't.
+**This is the highest-value section for LLM maintainers** because LLMs pattern-match aggressively
+and will "fix" intentional deviations unless warned.
+
+```markdown
+<!-- @hs:section id="gotchas" title="Gotchas" -->
+## Gotchas
+
+<!-- @hs:item id="gotchas.timing" title="Constant-time comparison is intentional" -->
+The password comparison in `_check_password()` uses `hmac.compare_digest()` instead of `==`.
+This looks unnecessarily complex but prevents timing attacks. Do NOT simplify this to a direct
+string comparison.
+<!-- @/hs:item -->
+
+<!-- @hs:item id="gotchas.sleep" title="Sleep after failed login is intentional" -->
+The 100ms sleep after a failed login attempt in `_handle_failed_attempt()` is a rate-limiting
+measure, not dead code. Do not remove it.
+<!-- @/hs:item -->
+
+<!-- @hs:item id="gotchas.no_cache" title="Login responses must never be cached" -->
+The `Cache-Control: no-store` header on login responses is set explicitly even though the
+framework default already prevents caching. This is defense-in-depth — do not rely on framework
+defaults for security-sensitive responses.
+<!-- @/hs:item -->
+
+<!-- @/hs:section -->
+```
+
+### Contracts / Invariants
+
+What must always be true about this module. Loaded per-component so the agent only sees the
+contracts relevant to what it is modifying.
+
+```markdown
+<!-- @hs:section id="contracts" title="Contracts" -->
+## Contracts
+
+<!-- @hs:item id="contracts.login_handler" title="LoginHandler contracts" -->
+**Preconditions:**
+- `email` parameter must be a valid email string (enforced by Pydantic at the boundary)
+- `password` parameter must be non-empty (enforced by Pydantic at the boundary)
+
+**Postconditions:**
+- On success: returns a `SessionToken` with `expires_at` > `now()`
+- On failure: returns a `LoginError` with a specific error code. NEVER returns a raw exception.
+
+**Invariants:**
+- `LoginHandler` never stores passwords in memory beyond the scope of a single `login()` call.
+- `LoginHandler` never logs the password value, even at DEBUG level.
+- Failed login attempts always take the same wall-clock time as successful ones (± 10ms) to
+  prevent timing attacks.
+<!-- @/hs:item -->
+
+<!-- @hs:item id="contracts.login_config" title="LoginConfig contracts" -->
+**Invariants:**
+- `max_attempts` is always > 0 and <= 100.
+- `lockout_duration_seconds` is always > 0.
+- These constraints are enforced by Pydantic validators at config load time.
+<!-- @/hs:item -->
+
+<!-- @/hs:section -->
+```
+
+### Related Atoms
+
+Which other modules interact with this one and how — not just dependency declarations (those are
+in index.toml) but the semantic relationship.
+
+```markdown
+<!-- @hs:section id="related" title="Related Atoms" -->
+## Related Atoms
+
+<!-- @hs:item id="related.session" title="Session relationship" -->
+**`src.features.auth.session`** — This atom creates sessions after successful login. The
+relationship is strictly one-directional: login calls `session.create()`, session never calls
+back into login. If session creation semantics change, the login handler may need to update
+its error handling for new session creation failure modes.
+<!-- @/hs:item -->
+
+<!-- @hs:item id="related.notifications" title="Notifications relationship" -->
+**`src.features.notifications.dispatch`** — Login emits a `LoginEvent` that the notification
+dispatcher consumes asynchronously. Login does not depend on notifications — it fires the event
+and forgets. If the event schema changes, both atoms must be updated.
+<!-- @/hs:item -->
+
+<!-- @/hs:section -->
+```
+
+### Examples / Usage
+
+Canonical usage snippets showing how the public API is meant to be called. Loadable per-API so
+the agent only sees examples for what it is working with.
+
+```markdown
+<!-- @hs:section id="examples" title="Examples" -->
+## Examples
+
+<!-- @hs:item id="examples.login_handler" title="LoginHandler usage" -->
+```python
+from src.features.auth.login.login import LoginHandler, LoginConfig
+
+config = LoginConfig(
+    max_attempts=5,
+    lockout_duration_seconds=300,
+)
+handler = LoginHandler(config=config, db=db_connection, session_factory=session_factory)
+
+result = handler.login(email="user@example.com", password="correct-password")
+match result:
+    case SessionToken() as token:
+        print(f"Login successful, expires at {token.expires_at}")
+    case LoginError() as error:
+        print(f"Login failed: {error.code}")
+```
+<!-- @/hs:item -->
+
+<!-- @hs:item id="examples.oauth_login" title="OAuth2 login usage" -->
+```python
+result = handler.login_oauth(
+    provider="google",
+    authorization_code="abc123",
+    redirect_uri="https://app.example.com/callback",
+)
+```
+<!-- @/hs:item -->
+
+<!-- @/hs:section -->
+```
+
+### Changelog / Decision Log
+
+Curated record of why things changed. Not git history — semantic decisions.
+
+```markdown
+<!-- @hs:section id="changelog" title="Changelog" -->
+## Changelog
+
+<!-- @hs:item id="changelog.v3_sync" title="v3: Switched from async to sync" -->
+**v3 (2025-11-15):** Switched `login()` from async to sync. Reason: the downstream session
+store (Redis) was replaced with an in-process SQLite store, eliminating the need for async IO.
+The async version introduced unnecessary complexity (cancellation handling, timeout management)
+for what is now a synchronous operation. Do not re-introduce async without a genuine async
+dependency.
+<!-- @/hs:item -->
+
+<!-- @hs:item id="changelog.v2_timing" title="v2: Added constant-time comparison" -->
+**v2 (2025-09-01):** Added constant-time password comparison and fixed-duration login attempts.
+Reason: security audit identified timing side-channel. See gotchas section for details on why
+this must not be simplified.
+<!-- @/hs:item -->
+
+<!-- @/hs:section -->
+```
+
+### FAQ
+
+Questions with individually loadable answers. The MCP server returns questions as a numbered
+list. The agent identifies which question is relevant and requests only that answer.
+
+```markdown
+<!-- @hs:section id="faq" title="FAQ" -->
+## FAQ
+
+<!-- @hs:faq id="1" question="Why does login() return a Result type instead of raising exceptions?" -->
+Python idiom favors exceptions, but this module is on a critical security path. A Result type
+makes error handling explicit at every call site — the caller cannot accidentally ignore a login
+failure by forgetting a try/except. The `LoginError` type carries structured error codes that
+enable programmatic handling (e.g., `ACCOUNT_LOCKED` triggers a different UI flow than
+`INVALID_CREDENTIALS`). Switching to exceptions would require auditing every call site to ensure
+proper handling.
+<!-- @/hs:faq -->
+
+<!-- @hs:faq id="2" question="Why is there a 100ms sleep after failed login?" -->
+Rate-limiting against brute force attacks. The sleep ensures that an attacker cannot determine
+whether a failure was due to an invalid email (user doesn't exist) vs. invalid password (user
+exists but password is wrong) by measuring response time. Combined with the constant-time
+comparison (see gotchas), this makes all failed logins indistinguishable from the attacker's
+perspective.
+<!-- @/hs:faq -->
+
+<!-- @hs:faq id="3" question="Why was a type: ignore set at line 47 in login.py?" -->
+Line 47 calls `session.create()` which returns `SessionToken | None`. Pyright strict mode flags
+the `None` case as unhandled. However, `session.create()` only returns `None` when the session
+store is in read-only mode, which is checked and prevented by an assertion at handler
+initialization (see contracts). The type: ignore is justified because the `None` path is
+structurally unreachable after initialization. Removing the ignore would require either an
+unnecessary runtime check or a protocol change in the session module.
+<!-- @/hs:faq -->
+
+<!-- @/hs:section -->
+```
+
+---
+
+## Disclosure Levels
+
+The MCP server processes requests at these disclosure levels:
+
+| Level | What Is Returned | When to Use |
+|-------|-----------------|-------------|
+| `brief` | Brief section only | Navigation, discovery, understanding what an atom is |
+| `section` | A specific named section | The agent needs architecture, gotchas, contracts, etc. |
+| `item` | A specific item within a section | The agent needs one contract, one example, one changelog entry |
+| `faq_list` | All FAQ questions (no answers) | The agent needs to find which FAQ is relevant |
+| `faq` | A specific FAQ answer by ID | The agent found the relevant question |
+| `integrity` | The integrity hash block | CI verification, or agent verifying after modification |
+| `full` | The entire README | Rare — only when the agent needs everything (e.g., rewriting the README) |
+
+---
+
+## Sub-Sections
+
+Sections contain items. Items are the finest granularity of disclosure. The `id` attribute
+provides a stable reference path:
+
+```
+readme("/src/features/auth/login", section="contracts")           → all contracts
+readme("/src/features/auth/login", item="contracts.login_handler") → one contract
+readme("/src/features/auth/login", section="examples")             → all examples
+readme("/src/features/auth/login", item="examples.oauth_login")    → one example
+readme("/src/features/auth/login", section="faq")                  → question list only
+readme("/src/features/auth/login", faq="2")                        → answer to question 2
+```
+
+Items can be further nested if needed (e.g., a contract item containing sub-items for
+preconditions, postconditions, invariants). The MCP server handles arbitrary nesting depth.
+
+---
+
+## Integrity Block
+
+The integrity block is a special section that contains SHA-256 hashes of every file in the
+directory (excluding README.md itself).
+
+```markdown
+<!-- @hs:integrity -->
+## Integrity
+
+| File | SHA-256 |
+|------|---------|
+| index.toml | a1b2c3d4e5f6... |
+| login.py | f6e5d4c3b2a1... |
+| test_login.py | 1a2b3c4d5e6f... |
+| fixtures/sample_input.json | 6f5e4d3c2b1a... |
+<!-- @/hs:integrity -->
+```
+
+Rules:
+- Hashes cover every file and directory in the same directory as the README.md.
+- `README.md` itself is excluded (it cannot hash itself).
+- `index.toml` IS included (cross-validation: README hashes index.toml, index.toml hashes README).
+- Subdirectories are hashed as the SHA-256 of their own `index.toml` content. This creates a
+  Merkle-like chain — if any file in a subdirectory changes, the subdirectory's index.toml hash
+  changes, which changes the parent's integrity block.
+- The hash is of the file's raw bytes, hex-encoded, lowercase.
+- Entries are sorted alphabetically by file path for deterministic output.
+
+---
+
+## Full Example
+
+A complete README.md for a login handler atom:
+
+```markdown
+<!-- @hs:brief -->
+# Login Handler
+
+Handles user authentication via username/password and OAuth2 flows.
+
+**Exports:** `LoginHandler`, `LoginConfig`, `LoginError`
+
+**Files:**
+- `login.py` — Core login logic and session creation
+- `test_login.py` — Unit and property-based tests
+- `fixtures/` — Test credentials and mock OAuth responses
+
+**Dependencies:**
+- `src.features.auth.session` — Session creation after successful login
+- `src.core.validation.email_format` — Email input validation
+- `src.infra.database.connection` — User credential lookup
+<!-- @/hs:brief -->
+
+<!-- @hs:section id="architecture" title="Architecture" -->
+## Architecture
+
+[Architecture content here]
+<!-- @/hs:section -->
+
+<!-- @hs:section id="gotchas" title="Gotchas" -->
+## Gotchas
+
+<!-- @hs:item id="gotchas.timing" title="Constant-time comparison is intentional" -->
+[Gotcha content here]
+<!-- @/hs:item -->
+
+<!-- @/hs:section -->
+
+<!-- @hs:section id="contracts" title="Contracts" -->
+## Contracts
+
+<!-- @hs:item id="contracts.login_handler" title="LoginHandler contracts" -->
+[Contract content here]
+<!-- @/hs:item -->
+
+<!-- @/hs:section -->
+
+<!-- @hs:section id="related" title="Related Atoms" -->
+## Related Atoms
+
+<!-- @hs:item id="related.session" title="Session relationship" -->
+[Related content here]
+<!-- @/hs:item -->
+
+<!-- @/hs:section -->
+
+<!-- @hs:section id="examples" title="Examples" -->
+## Examples
+
+<!-- @hs:item id="examples.login_handler" title="LoginHandler usage" -->
+[Example content here]
+<!-- @/hs:item -->
+
+<!-- @/hs:section -->
+
+<!-- @hs:section id="changelog" title="Changelog" -->
+## Changelog
+
+<!-- @hs:item id="changelog.v3_sync" title="v3: Switched from async to sync" -->
+[Changelog content here]
+<!-- @/hs:item -->
+
+<!-- @/hs:section -->
+
+<!-- @hs:section id="faq" title="FAQ" -->
+## FAQ
+
+<!-- @hs:faq id="1" question="Why does login() return a Result type instead of raising exceptions?" -->
+[Answer content here]
+<!-- @/hs:faq -->
+
+<!-- @/hs:section -->
+
+<!-- @hs:integrity -->
+## Integrity
+
+| File | SHA-256 |
+|------|---------|
+| index.toml | a1b2c3d4e5f6... |
+| login.py | f6e5d4c3b2a1... |
+| test_login.py | 1a2b3c4d5e6f... |
+| fixtures/sample_input.json | 6f5e4d3c2b1a... |
+<!-- @/hs:integrity -->
+```
+
+---
+
+## Rendering Behavior
+
+### On GitHub / GitLab
+
+HTML comments are invisible. The README renders as a normal markdown document with all sections
+visible. This is by design — when browsing on GitHub, you see everything. Progressive disclosure
+is an agent optimization, not a human optimization.
+
+### Via MCP Server
+
+The MCP server parses the markers and serves sections individually. The agent never receives the
+full document unless it explicitly requests `level="full"`.
+
+### In Plain Editors
+
+The markers are visible as HTML comments. They are designed to be human-readable even in raw
+form — a developer editing the README can see the structure.
+
+---
+
+## Authoring Rules
+
+1. **Brief is mandatory.** Every README.md must have a `<!-- @hs:brief -->` section.
+2. **Integrity is mandatory.** Every README.md must have a `<!-- @hs:integrity -->` section.
+3. **All other sections are optional** but strongly encouraged. At minimum, atoms with non-trivial
+   logic should have: architecture, contracts, and examples.
+4. **IDs are stable.** Once an item has an ID, that ID does not change (even if the content changes).
+   Other atoms may reference items by ID in their own documentation. Changing an ID is a breaking
+   change to the documentation API.
+5. **IDs use dot-separated paths.** `contracts.login_handler`, `examples.oauth_login`,
+   `gotchas.timing`. The prefix matches the section ID.
+6. **FAQ question text should be self-contained.** An agent reading just the question (without the
+   answer) should understand what the question is asking and be able to decide if it is relevant
+   to the current task.
+7. **Updating a file requires updating integrity hashes.** This is enforced by CI. The agent
+   must recompute hashes after any file modification. Use `scripts/readme_hooks.py` to automate.
+8. **README updates are part of the change.** If you modify a file in an atom, updating the
+   README's integrity hashes (and any content sections affected by the change) is part of the
+   same operation. An incomplete change is one that modifies code but not manifests.

--- a/plugins/hypersaint/skills/hypersaint/scripts/index_toml_generator.py
+++ b/plugins/hypersaint/skills/hypersaint/scripts/index_toml_generator.py
@@ -1,0 +1,240 @@
+"""Hypersaint index.toml Generator.
+
+Generates or updates the index.toml manifest for a target directory.
+Computes SHA-256 hashes of all sibling files and directories, and writes
+a valid Hypersaint index.toml with the [integrity] table populated.
+
+Usage:
+    python index_toml_generator.py <target_dir> [--update]
+
+Arguments:
+    target_dir  Path to the directory to generate index.toml for.
+    --update    If set, preserve existing [exports], [dependencies], [circular],
+                [children], and description fields. Only regenerate [integrity].
+                If not set, generate a skeleton index.toml with empty tables.
+
+Behavior:
+    - Scans all files and directories in target_dir (excluding index.toml itself
+      and ignored patterns).
+    - Computes SHA-256 hash of each file.
+    - For subdirectories, computes SHA-256 of their index.toml (errors if missing).
+    - Writes index.toml with sorted [integrity] entries.
+    - In --update mode: reads existing index.toml, preserves non-integrity tables,
+      replaces [integrity] with freshly computed hashes.
+
+Ignored Patterns:
+    .git, __pycache__, node_modules, .mypy_cache, .ruff_cache, .pytest_cache,
+    dist, build, .DS_Store, *.pyc, *.pyo
+
+Exit Codes:
+    0  Success
+    1  Target directory does not exist
+    2  A subdirectory is missing its index.toml (cannot compute directory hash)
+    3  Write error
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import sys
+from pathlib import Path
+
+IGNORE_DIRS: frozenset[str] = frozenset({
+    ".git",
+    "__pycache__",
+    "node_modules",
+    ".mypy_cache",
+    ".ruff_cache",
+    ".pytest_cache",
+    "dist",
+    "build",
+    ".venv",
+    "venv",
+    ".tox",
+    ".nox",
+    ".eggs",
+    "*.egg-info",
+})
+
+IGNORE_FILES: frozenset[str] = frozenset({
+    ".DS_Store",
+    "Thumbs.db",
+})
+
+IGNORE_EXTENSIONS: frozenset[str] = frozenset({
+    ".pyc",
+    ".pyo",
+    ".pyd",
+    ".so",
+    ".dylib",
+})
+
+
+def sha256_file(path: Path) -> str:
+    """Compute SHA-256 hex digest of a file's raw bytes."""
+    sha = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            sha.update(chunk)
+    return sha.hexdigest()
+
+
+def sha256_directory(path: Path) -> str:
+    """Compute hash of a directory by hashing its index.toml content."""
+    index_path = path / "index.toml"
+    if not index_path.exists():
+        print(
+            f"ERROR: Subdirectory '{path}' is missing index.toml. "
+            "Cannot compute directory hash. Create index.toml first.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    return sha256_file(index_path)
+
+
+def should_ignore(name: str, is_dir: bool) -> bool:
+    """Check if a file or directory should be ignored."""
+    if is_dir:
+        return name in IGNORE_DIRS or name.endswith(".egg-info")
+    if name in IGNORE_FILES:
+        return True
+    return Path(name).suffix in IGNORE_EXTENSIONS
+
+
+def collect_entries(target_dir: Path) -> dict[str, str]:
+    """Collect all sibling files/dirs and their hashes, excluding index.toml itself."""
+    entries: dict[str, str] = {}
+
+    for item in sorted(target_dir.iterdir()):
+        name = item.name
+
+        if name == "index.toml":
+            continue
+
+        if item.is_dir():
+            if should_ignore(name, is_dir=True):
+                continue
+            entries[name] = sha256_directory(item)
+        elif item.is_file():
+            if should_ignore(name, is_dir=False):
+                continue
+            entries[name] = sha256_file(item)
+
+    return entries
+
+
+def read_existing_toml(path: Path) -> dict[str, object]:
+    """Read existing index.toml and return parsed tables (excluding [integrity])."""
+    if not path.exists():
+        return {}
+
+    try:
+        import tomllib
+    except ImportError:
+        import tomli as tomllib  # type: ignore[no-redef]
+
+    with path.open("rb") as f:
+        data = tomllib.load(f)
+
+    data.pop("integrity", None)
+    return data
+
+
+def format_toml(data: dict[str, object], integrity: dict[str, str]) -> str:
+    """Format a complete index.toml string from data tables and integrity hashes."""
+    lines: list[str] = []
+
+    # Top-level description (optional)
+    if "description" in data:
+        desc = data["description"]
+        lines.append(f'description = "{desc}"')
+        lines.append("")
+
+    # [exports]
+    exports = data.get("exports", {"symbols": []})
+    lines.append("[exports]")
+    symbols = exports.get("symbols", []) if isinstance(exports, dict) else []
+    symbols_str = ", ".join(f'"{s}"' for s in symbols)
+    lines.append(f"symbols = [{symbols_str}]")
+    lines.append("")
+
+    # [dependencies]
+    deps = data.get("dependencies", {})
+    lines.append("[dependencies]")
+    if isinstance(deps, dict) and deps:
+        for path, syms in sorted(deps.items()):
+            if isinstance(syms, list):
+                syms_str = ", ".join(f'"{s}"' for s in syms)
+                lines.append(f'"{path}" = [{syms_str}]')
+    lines.append("")
+
+    # [circular] (only if present)
+    circular = data.get("circular", {})
+    if isinstance(circular, dict) and circular:
+        lines.append("[circular]")
+        for path, justification in sorted(circular.items()):
+            lines.append(f'"{path}" = "{justification}"')
+        lines.append("")
+
+    # [children] (only if present)
+    children = data.get("children", {})
+    if isinstance(children, dict) and children:
+        lines.append("[children]")
+        for name, desc in sorted(children.items()):
+            lines.append(f'{name} = "{desc}"')
+        lines.append("")
+
+    # [integrity]
+    lines.append("[integrity]")
+    for name, hash_val in sorted(integrity.items()):
+        lines.append(f'"{name}" = "{hash_val}"')
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+def generate_index_toml(target_dir: Path, *, update: bool = False) -> None:
+    """Generate or update index.toml for the target directory."""
+    index_path = target_dir / "index.toml"
+
+    # Collect integrity hashes
+    entries = collect_entries(target_dir)
+
+    if update and index_path.exists():
+        # Preserve existing non-integrity data
+        existing = read_existing_toml(index_path)
+    else:
+        # Generate skeleton
+        existing = {}
+
+    content = format_toml(existing, entries)
+
+    try:
+        index_path.write_text(content, encoding="utf-8")
+    except OSError as e:
+        print(f"ERROR: Failed to write {index_path}: {e}", file=sys.stderr)
+        sys.exit(3)
+
+    print(f"{'Updated' if update else 'Generated'}: {index_path}")
+    print(f"  Entries: {len(entries)}")
+
+
+def main() -> None:
+    """Entry point."""
+    if len(sys.argv) < 2:
+        print("Usage: python index_toml_generator.py <target_dir> [--update]", file=sys.stderr)
+        sys.exit(1)
+
+    target = Path(sys.argv[1]).resolve()
+    update = "--update" in sys.argv
+
+    if not target.is_dir():
+        print(f"ERROR: '{target}' is not a directory.", file=sys.stderr)
+        sys.exit(1)
+
+    generate_index_toml(target, update=update)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/hypersaint/skills/hypersaint/scripts/readme_hooks.py
+++ b/plugins/hypersaint/skills/hypersaint/scripts/readme_hooks.py
@@ -1,0 +1,338 @@
+"""Hypersaint README Hooks — Top-Down README Integrity Updater.
+
+Given a set of changed files, determines ALL directories whose README.md integrity
+blocks need updating, collects them top-down, and updates them in the correct order
+(leaf-first, then propagate upward to root).
+
+Usage:
+    python readme_hooks.py <repo_root> --changed <file1> [file2 ...]
+    python readme_hooks.py <repo_root> --directory <dir1> [dir2 ...]
+    python readme_hooks.py <repo_root> --all
+
+Arguments:
+    repo_root       Path to the repository root.
+    --changed       List of changed file paths (relative to repo_root). The script
+                    determines which directories are affected and updates their READMEs.
+    --directory     Directly specify directories to update.
+    --all           Update ALL READMEs in the entire repository.
+    --dry-run       Print what would be updated without writing changes.
+
+Strategy:
+    1. COLLECT: From the changed files, determine all directories that need updates.
+       A directory needs an update if:
+       - Any of its direct children (files or subdirectories) were modified.
+       - Any of its subdirectories had their index.toml or README.md modified
+         (because the parent hashes subdirectories via their index.toml).
+
+    2. SORT: Topologically sort directories leaf-first (deepest first). This ensures
+       that when we update a parent's hashes, the children's index.toml files are
+       already up to date.
+
+    3. UPDATE: For each directory (leaf to root):
+       a. Recompute SHA-256 hashes of all sibling files (excluding README.md itself).
+       b. Parse the existing README.md to find the <!-- @hs:integrity --> block.
+       c. Replace the integrity block content with updated hashes.
+       d. Write the updated README.md.
+
+    4. ALSO UPDATE index.toml: After updating README.md, the README.md hash in
+       index.toml is now stale. Re-run index_toml_generator in --update mode for
+       each affected directory.
+
+Exit Codes:
+    0  Success (or dry-run)
+    1  Invalid arguments
+    2  Repository root not found
+    3  A directory is missing README.md or index.toml
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import sys
+from pathlib import Path
+
+IGNORE_DIRS: frozenset[str] = frozenset({
+    ".git",
+    "__pycache__",
+    "node_modules",
+    ".mypy_cache",
+    ".ruff_cache",
+    ".pytest_cache",
+    "dist",
+    "build",
+    ".venv",
+    "venv",
+    ".tox",
+    ".nox",
+    ".eggs",
+    ".github",
+})
+
+IGNORE_FILES: frozenset[str] = frozenset({
+    ".DS_Store",
+    "Thumbs.db",
+})
+
+IGNORE_EXTENSIONS: frozenset[str] = frozenset({
+    ".pyc",
+    ".pyo",
+    ".pyd",
+    ".so",
+    ".dylib",
+})
+
+INTEGRITY_START = "<!-- @hs:integrity -->"
+INTEGRITY_END = "<!-- @/hs:integrity -->"
+
+
+def sha256_file(path: Path) -> str:
+    """Compute SHA-256 hex digest of a file's raw bytes."""
+    sha = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            sha.update(chunk)
+    return sha.hexdigest()
+
+
+def sha256_directory(path: Path) -> str:
+    """Compute hash of a directory via its index.toml."""
+    index_path = path / "index.toml"
+    if not index_path.exists():
+        return "MISSING_INDEX_TOML"
+    return sha256_file(index_path)
+
+
+def should_ignore(name: str, is_dir: bool) -> bool:
+    """Check if a file or directory should be ignored."""
+    if is_dir:
+        return name in IGNORE_DIRS or name.endswith(".egg-info")
+    if name in IGNORE_FILES:
+        return True
+    return Path(name).suffix in IGNORE_EXTENSIONS
+
+
+def compute_integrity_entries(directory: Path) -> dict[str, str]:
+    """Compute hashes for all siblings of README.md in a directory (excluding README.md)."""
+    entries: dict[str, str] = {}
+
+    for item in sorted(directory.iterdir()):
+        name = item.name
+
+        if name == "README.md":
+            continue
+
+        if item.is_dir():
+            if should_ignore(name, is_dir=True):
+                continue
+            entries[name] = sha256_directory(item)
+        elif item.is_file():
+            if should_ignore(name, is_dir=False):
+                continue
+            entries[name] = sha256_file(item)
+
+    return entries
+
+
+def format_integrity_block(entries: dict[str, str]) -> str:
+    """Format entries as a markdown integrity table."""
+    lines: list[str] = [
+        INTEGRITY_START,
+        "## Integrity",
+        "",
+        "| File | SHA-256 |",
+        "|------|---------|",
+    ]
+
+    for name, hash_val in sorted(entries.items()):
+        lines.append(f"| {name} | {hash_val} |")
+
+    lines.append(INTEGRITY_END)
+    return "\n".join(lines)
+
+
+def update_readme_integrity(readme_path: Path, entries: dict[str, str]) -> bool:
+    """Update the integrity block in a README.md. Returns True if changed."""
+    if not readme_path.exists():
+        return False
+
+    content = readme_path.read_text(encoding="utf-8")
+    new_block = format_integrity_block(entries)
+
+    # Find existing integrity block
+    pattern = re.compile(
+        re.escape(INTEGRITY_START) + r".*?" + re.escape(INTEGRITY_END),
+        re.DOTALL,
+    )
+
+    match = pattern.search(content)
+    if match:
+        new_content = content[: match.start()] + new_block + content[match.end() :]
+    else:
+        # No existing integrity block — append at end
+        new_content = content.rstrip() + "\n\n" + new_block + "\n"
+
+    if new_content == content:
+        return False
+
+    readme_path.write_text(new_content, encoding="utf-8")
+    return True
+
+
+def find_affected_directories(
+    repo_root: Path,
+    changed_files: list[Path],
+) -> set[Path]:
+    """Determine all directories needing README/index.toml updates.
+
+    A directory is affected if:
+    1. It directly contains a changed file.
+    2. Any of its child directories were affected (propagation upward).
+    """
+    affected: set[Path] = set()
+
+    for changed_file in changed_files:
+        # The directory containing the changed file
+        parent = changed_file.parent
+        if parent.is_relative_to(repo_root):
+            affected.add(parent)
+
+            # Propagate upward: every ancestor up to repo_root is affected
+            # because their integrity hash of the child directory changes
+            current = parent.parent
+            while current >= repo_root:
+                affected.add(current)
+                if current == repo_root:
+                    break
+                current = current.parent
+
+    return affected
+
+
+def find_all_directories(repo_root: Path) -> set[Path]:
+    """Find all Hypersaint-managed directories (those with README.md or index.toml)."""
+    result: set[Path] = set()
+
+    for dirpath, dirnames, _filenames in os.walk(repo_root):
+        # Filter ignored directories in-place to prevent os.walk from descending
+        dirnames[:] = [
+            d for d in dirnames if not should_ignore(d, is_dir=True)
+        ]
+
+        path = Path(dirpath)
+        if (path / "README.md").exists() or (path / "index.toml").exists():
+            result.add(path)
+
+    return result
+
+
+def topological_sort_leaf_first(directories: set[Path]) -> list[Path]:
+    """Sort directories deepest-first so leaf updates happen before parent updates."""
+    return sorted(directories, key=lambda p: len(p.parts), reverse=True)
+
+
+def update_directory(directory: Path, *, dry_run: bool = False) -> tuple[bool, bool]:
+    """Update README.md and index.toml integrity for a single directory.
+
+    Returns (readme_changed, index_changed).
+    """
+    readme_path = directory / "README.md"
+    index_path = directory / "index.toml"
+
+    if not readme_path.exists():
+        print(f"  SKIP {directory} — no README.md", file=sys.stderr)
+        return False, False
+
+    # Compute integrity entries for README (excludes README.md itself)
+    readme_entries = compute_integrity_entries(directory)
+
+    if dry_run:
+        print(f"  WOULD UPDATE: {readme_path}")
+        print(f"    Entries: {len(readme_entries)}")
+        return True, True
+
+    # Update README integrity block
+    readme_changed = update_readme_integrity(readme_path, readme_entries)
+
+    # Now update index.toml (which needs the hash of the updated README.md)
+    index_changed = False
+    if index_path.exists():
+        # Re-run the index.toml generator in update mode
+        # Import and call directly to avoid subprocess overhead
+        from index_toml_generator import generate_index_toml
+
+        generate_index_toml(directory, update=True)
+        index_changed = True
+
+    return readme_changed, index_changed
+
+
+def main() -> None:
+    """Entry point."""
+    if len(sys.argv) < 3:
+        print(
+            "Usage:\n"
+            "  python readme_hooks.py <repo_root> --changed <file1> [file2 ...]\n"
+            "  python readme_hooks.py <repo_root> --directory <dir1> [dir2 ...]\n"
+            "  python readme_hooks.py <repo_root> --all\n"
+            "  Add --dry-run to preview changes.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    repo_root = Path(sys.argv[1]).resolve()
+    if not repo_root.is_dir():
+        print(f"ERROR: '{repo_root}' is not a directory.", file=sys.stderr)
+        sys.exit(2)
+
+    dry_run = "--dry-run" in sys.argv
+    args = [a for a in sys.argv[2:] if a != "--dry-run"]
+
+    if "--all" in args:
+        directories = find_all_directories(repo_root)
+    elif "--changed" in args:
+        idx = args.index("--changed")
+        changed_paths = [
+            (repo_root / p).resolve() for p in args[idx + 1 :] if not p.startswith("--")
+        ]
+        directories = find_affected_directories(repo_root, changed_paths)
+    elif "--directory" in args:
+        idx = args.index("--directory")
+        directories = {
+            (repo_root / p).resolve() for p in args[idx + 1 :] if not p.startswith("--")
+        }
+    else:
+        print("ERROR: Must specify --changed, --directory, or --all.", file=sys.stderr)
+        sys.exit(1)
+
+    if not directories:
+        print("No directories to update.")
+        return
+
+    # Sort leaf-first for correct propagation order
+    sorted_dirs = topological_sort_leaf_first(directories)
+
+    print(f"Updating {len(sorted_dirs)} directories ({'DRY RUN' if dry_run else 'LIVE'}):")
+    print()
+
+    readme_count = 0
+    index_count = 0
+
+    for directory in sorted_dirs:
+        rel = directory.relative_to(repo_root)
+        print(f"  Processing: {rel}/")
+
+        readme_changed, index_changed = update_directory(directory, dry_run=dry_run)
+
+        if readme_changed:
+            readme_count += 1
+        if index_changed:
+            index_count += 1
+
+    print()
+    print(f"Summary: {readme_count} READMEs updated, {index_count} index.toml files updated.")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/hypersaint/skills/hypersaint/scripts/verify_integrity.py
+++ b/plugins/hypersaint/skills/hypersaint/scripts/verify_integrity.py
@@ -1,0 +1,462 @@
+"""Hypersaint Integrity Verification Script.
+
+Walks the entire repository and verifies that all README.md and index.toml
+manifests are in sync with actual file contents.
+
+Usage:
+    python verify_integrity.py <repo_root> [--strict] [--json]
+
+Arguments:
+    repo_root   Path to the repository root.
+    --strict    Exit with code 1 on ANY error (default for CI).
+    --json      Output errors as JSON (one object per line) for machine parsing.
+
+Checks Performed:
+    1. Every directory (except ignored) has both README.md and index.toml.
+    2. Every hash in index.toml [integrity] matches the actual file.
+    3. Every file in the directory has an entry in index.toml [integrity].
+    4. No extra entries in index.toml [integrity] (referencing deleted files).
+    5. Every hash in README.md <!-- @hs:integrity --> matches the actual file.
+    6. Every file has an entry in README.md integrity block.
+    7. No extra entries in README.md integrity block.
+    8. Cross-validation: index.toml's hash of README.md matches actual README.md.
+    9. Cross-validation: README.md's hash of index.toml matches actual index.toml.
+    10. Circular dependency symmetry: if A declares circular with B, B must
+        declare circular with A.
+
+Output Format (default):
+    One error per line:
+    ERROR_CODE: path details
+
+Output Format (--json):
+    One JSON object per line:
+    {"code": "HASH_MISMATCH", "path": "src/auth/login.py", "declared": "abc...", "actual": "def..."}
+
+Exit Codes:
+    0  All checks pass
+    1  One or more checks failed (with --strict, which is default)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib  # type: ignore[no-redef]
+
+IGNORE_DIRS: frozenset[str] = frozenset({
+    ".git",
+    "__pycache__",
+    "node_modules",
+    ".mypy_cache",
+    ".ruff_cache",
+    ".pytest_cache",
+    "dist",
+    "build",
+    ".venv",
+    "venv",
+    ".tox",
+    ".nox",
+    ".eggs",
+    ".github",
+})
+
+IGNORE_FILES: frozenset[str] = frozenset({
+    ".DS_Store",
+    "Thumbs.db",
+})
+
+IGNORE_EXTENSIONS: frozenset[str] = frozenset({
+    ".pyc",
+    ".pyo",
+    ".pyd",
+    ".so",
+    ".dylib",
+})
+
+INTEGRITY_START = "<!-- @hs:integrity -->"
+INTEGRITY_END = "<!-- @/hs:integrity -->"
+
+
+@dataclass(frozen=True, slots=True)
+class IntegrityError:
+    """A single integrity violation."""
+
+    code: str
+    path: str
+    message: str
+    declared: str = ""
+    actual: str = ""
+
+    def to_line(self) -> str:
+        """Format as a human-readable error line."""
+        parts = [f"{self.code}: {self.path}"]
+        if self.declared and self.actual:
+            parts.append(f"declared={self.declared[:16]}... actual={self.actual[:16]}...")
+        parts.append(self.message)
+        return " ".join(parts)
+
+    def to_json(self) -> str:
+        """Format as a JSON line."""
+        data: dict[str, str] = {
+            "code": self.code,
+            "path": self.path,
+            "message": self.message,
+        }
+        if self.declared:
+            data["declared"] = self.declared
+        if self.actual:
+            data["actual"] = self.actual
+        return json.dumps(data)
+
+
+def sha256_file(path: Path) -> str:
+    """Compute SHA-256 hex digest of a file."""
+    sha = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            sha.update(chunk)
+    return sha.hexdigest()
+
+
+def sha256_directory(path: Path) -> str:
+    """Compute hash of a directory via its index.toml."""
+    index_path = path / "index.toml"
+    if not index_path.exists():
+        return "MISSING"
+    return sha256_file(index_path)
+
+
+def should_ignore(name: str, is_dir: bool) -> bool:
+    """Check if a file or directory should be ignored."""
+    if is_dir:
+        return name in IGNORE_DIRS or name.endswith(".egg-info")
+    if name in IGNORE_FILES:
+        return True
+    return Path(name).suffix in IGNORE_EXTENSIONS
+
+
+def parse_readme_integrity(readme_path: Path) -> dict[str, str] | None:
+    """Parse the integrity block from a README.md. Returns None if no block found."""
+    if not readme_path.exists():
+        return None
+
+    content = readme_path.read_text(encoding="utf-8")
+
+    pattern = re.compile(
+        re.escape(INTEGRITY_START) + r"(.*?)" + re.escape(INTEGRITY_END),
+        re.DOTALL,
+    )
+    match = pattern.search(content)
+    if not match:
+        return None
+
+    block = match.group(1)
+    entries: dict[str, str] = {}
+
+    # Parse markdown table rows: | filename | hash |
+    row_pattern = re.compile(r"^\|\s*(.+?)\s*\|\s*([a-f0-9]{64})\s*\|", re.MULTILINE)
+    for row_match in row_pattern.finditer(block):
+        filename = row_match.group(1).strip()
+        hash_val = row_match.group(2).strip()
+        if filename not in ("File", "------", "---"):
+            entries[filename] = hash_val
+
+    return entries
+
+
+def parse_index_toml(index_path: Path) -> dict[str, object] | None:
+    """Parse index.toml. Returns None if file doesn't exist."""
+    if not index_path.exists():
+        return None
+
+    with index_path.open("rb") as f:
+        return tomllib.load(f)
+
+
+def get_actual_entries(directory: Path, *, exclude: str) -> dict[str, str]:
+    """Get actual file hashes for a directory, excluding the named file."""
+    entries: dict[str, str] = {}
+
+    for item in sorted(directory.iterdir()):
+        name = item.name
+        if name == exclude:
+            continue
+
+        if item.is_dir():
+            if should_ignore(name, is_dir=True):
+                continue
+            entries[name] = sha256_directory(item)
+        elif item.is_file():
+            if should_ignore(name, is_dir=False):
+                continue
+            entries[name] = sha256_file(item)
+
+    return entries
+
+
+def check_directory(directory: Path, repo_root: Path) -> list[IntegrityError]:
+    """Run all integrity checks on a single directory."""
+    errors: list[IntegrityError] = []
+    rel = str(directory.relative_to(repo_root))
+
+    readme_path = directory / "README.md"
+    index_path = directory / "index.toml"
+
+    # Check 1: Both manifests exist
+    if not readme_path.exists():
+        errors.append(IntegrityError(
+            code="MISSING_MANIFEST",
+            path=f"{rel}/README.md",
+            message="Directory is missing README.md",
+        ))
+    if not index_path.exists():
+        errors.append(IntegrityError(
+            code="MISSING_MANIFEST",
+            path=f"{rel}/index.toml",
+            message="Directory is missing index.toml",
+        ))
+
+    if not readme_path.exists() or not index_path.exists():
+        return errors
+
+    # Parse manifests
+    index_data = parse_index_toml(index_path)
+    readme_integrity = parse_readme_integrity(readme_path)
+
+    if index_data is None:
+        errors.append(IntegrityError(
+            code="MALFORMED_MANIFEST",
+            path=f"{rel}/index.toml",
+            message="Failed to parse TOML",
+        ))
+        return errors
+
+    # Get declared hashes
+    index_integrity: dict[str, str] = {}
+    if "integrity" in index_data and isinstance(index_data["integrity"], dict):
+        index_integrity = {str(k): str(v) for k, v in index_data["integrity"].items()}
+
+    # Compute actual hashes for index.toml (excludes index.toml itself)
+    actual_for_index = get_actual_entries(directory, exclude="index.toml")
+
+    # Check 2: index.toml hash accuracy
+    for name, declared in index_integrity.items():
+        if name in actual_for_index:
+            actual = actual_for_index[name]
+            if declared != actual:
+                errors.append(IntegrityError(
+                    code="HASH_MISMATCH",
+                    path=f"{rel}/{name}",
+                    message=f"Hash mismatch in index.toml",
+                    declared=declared,
+                    actual=actual,
+                ))
+
+    # Check 3: index.toml completeness (missing entries)
+    for name in actual_for_index:
+        if name not in index_integrity:
+            errors.append(IntegrityError(
+                code="MISSING_ENTRY",
+                path=f"{rel}/{name}",
+                message=f"File exists but not in index.toml [integrity]",
+            ))
+
+    # Check 4: index.toml extra entries
+    for name in index_integrity:
+        if name not in actual_for_index:
+            errors.append(IntegrityError(
+                code="EXTRA_ENTRY",
+                path=f"{rel}/{name}",
+                message=f"Entry in index.toml [integrity] but file does not exist",
+            ))
+
+    # Checks 5-7: README.md integrity block
+    if readme_integrity is not None:
+        actual_for_readme = get_actual_entries(directory, exclude="README.md")
+
+        for name, declared in readme_integrity.items():
+            if name in actual_for_readme:
+                actual = actual_for_readme[name]
+                if declared != actual:
+                    errors.append(IntegrityError(
+                        code="HASH_MISMATCH",
+                        path=f"{rel}/{name}",
+                        message=f"Hash mismatch in README.md integrity block",
+                        declared=declared,
+                        actual=actual,
+                    ))
+
+        for name in actual_for_readme:
+            if name not in readme_integrity:
+                errors.append(IntegrityError(
+                    code="MISSING_ENTRY",
+                    path=f"{rel}/{name}",
+                    message=f"File exists but not in README.md integrity block",
+                ))
+
+        for name in readme_integrity:
+            if name not in actual_for_readme:
+                errors.append(IntegrityError(
+                    code="EXTRA_ENTRY",
+                    path=f"{rel}/{name}",
+                    message=f"Entry in README.md integrity block but file does not exist",
+                ))
+
+    elif readme_path.exists():
+        errors.append(IntegrityError(
+            code="MISSING_INTEGRITY_BLOCK",
+            path=f"{rel}/README.md",
+            message="README.md exists but has no <!-- @hs:integrity --> block",
+        ))
+
+    # Check 8-9: Cross-validation
+    # index.toml should have hash of README.md
+    if "README.md" in index_integrity:
+        actual_readme_hash = sha256_file(readme_path)
+        if index_integrity["README.md"] != actual_readme_hash:
+            errors.append(IntegrityError(
+                code="CROSS_VALIDATION",
+                path=f"{rel}/index.toml",
+                message="index.toml hash of README.md is stale",
+                declared=index_integrity["README.md"],
+                actual=actual_readme_hash,
+            ))
+
+    # README.md should have hash of index.toml
+    if readme_integrity is not None and "index.toml" in readme_integrity:
+        actual_index_hash = sha256_file(index_path)
+        if readme_integrity["index.toml"] != actual_index_hash:
+            errors.append(IntegrityError(
+                code="CROSS_VALIDATION",
+                path=f"{rel}/README.md",
+                message="README.md hash of index.toml is stale",
+                declared=readme_integrity["index.toml"],
+                actual=actual_index_hash,
+            ))
+
+    return errors
+
+
+def check_circular_symmetry(
+    repo_root: Path,
+    all_dirs: list[Path],
+) -> list[IntegrityError]:
+    """Check that circular dependency declarations are symmetric."""
+    errors: list[IntegrityError] = []
+
+    # Collect all circular declarations
+    circular_decls: dict[str, dict[str, str]] = {}
+
+    for directory in all_dirs:
+        index_path = directory / "index.toml"
+        if not index_path.exists():
+            continue
+
+        data = parse_index_toml(index_path)
+        if data is None:
+            continue
+
+        circular = data.get("circular", {})
+        if isinstance(circular, dict) and circular:
+            rel = str(directory.relative_to(repo_root))
+            circular_decls[rel] = {str(k): str(v) for k, v in circular.items()}
+
+    # Check symmetry
+    for atom_path, deps in circular_decls.items():
+        for dep_path in deps:
+            if dep_path not in circular_decls:
+                errors.append(IntegrityError(
+                    code="CIRCULAR_ASYMMETRIC",
+                    path=atom_path,
+                    message=(
+                        f"Declares circular dependency with {dep_path} "
+                        f"but {dep_path} does not declare the reverse"
+                    ),
+                ))
+            elif atom_path not in circular_decls.get(dep_path, {}):
+                errors.append(IntegrityError(
+                    code="CIRCULAR_ASYMMETRIC",
+                    path=atom_path,
+                    message=(
+                        f"Declares circular dependency with {dep_path} "
+                        f"but {dep_path} does not list {atom_path} in [circular]"
+                    ),
+                ))
+
+    return errors
+
+
+def find_managed_directories(repo_root: Path) -> list[Path]:
+    """Find all directories that should be managed by Hypersaint."""
+    result: list[Path] = []
+
+    for dirpath, dirnames, _filenames in os.walk(repo_root):
+        dirnames[:] = [
+            d for d in dirnames if not should_ignore(d, is_dir=True)
+        ]
+
+        path = Path(dirpath)
+        # A directory is managed if it contains README.md, index.toml, or any .py/.ts/.rs file
+        has_manifest = (path / "README.md").exists() or (path / "index.toml").exists()
+        if has_manifest:
+            result.append(path)
+
+    return result
+
+
+def main() -> None:
+    """Entry point."""
+    if len(sys.argv) < 2:
+        print(
+            "Usage: python verify_integrity.py <repo_root> [--strict] [--json]",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    repo_root = Path(sys.argv[1]).resolve()
+    strict = "--strict" in sys.argv
+    use_json = "--json" in sys.argv
+
+    if not repo_root.is_dir():
+        print(f"ERROR: '{repo_root}' is not a directory.", file=sys.stderr)
+        sys.exit(1)
+
+    all_dirs = find_managed_directories(repo_root)
+    all_errors: list[IntegrityError] = []
+
+    for directory in all_dirs:
+        errors = check_directory(directory, repo_root)
+        all_errors.extend(errors)
+
+    # Check circular symmetry across the whole repo
+    all_errors.extend(check_circular_symmetry(repo_root, all_dirs))
+
+    # Output
+    if use_json:
+        for error in all_errors:
+            print(error.to_json())
+    else:
+        if all_errors:
+            print(f"Hypersaint Integrity Check: {len(all_errors)} error(s) found\n")
+            for error in all_errors:
+                print(f"  {error.to_line()}")
+            print()
+            print("Run 'python scripts/readme_hooks.py . --all' to fix integrity hashes.")
+        else:
+            print(f"Hypersaint Integrity Check: OK ({len(all_dirs)} directories verified)")
+
+    if all_errors and strict:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add `hypersaint` plugin — an LLM-native repository architecture framework with two pillars: hyperstrictness (maximum correctness on every configurable dial) and hypermodularity (self-describing directory atoms with progressive disclosure)
- Includes 1 skill (`hypersaint`), 6 reference docs, 3 Python scripts (`index_toml_generator.py`, `readme_hooks.py`, `verify_integrity.py`), and 1 CI template
- Follows existing plugin conventions: `.claude-plugin/plugin.json`, `README.md`, `skills/` directory with `SKILL.md` and supporting files

Closes #57

## Changes

```
plugins/hypersaint/
├── .claude-plugin/plugin.json           # Plugin metadata
├── README.md                            # User-facing documentation
└── skills/hypersaint/
    ├── SKILL.md                         # Main skill — core rules + decision guide
    ├── references/
    │   ├── philosophy.md                # Axioms, tool doctrine, strictness
    │   ├── modularity.md               # Atom structure, nesting, navigation model
    │   ├── readme_format.md            # Progressive disclosure marker syntax
    │   ├── index_toml_spec.md          # Machine-readable manifest schema
    │   ├── ci_integrity.md             # Hash verification and CI integration
    │   └── mcp_server_spec.md          # Navigation MCP server specification
    ├── scripts/
    │   ├── index_toml_generator.py     # Generate/update index.toml
    │   ├── readme_hooks.py             # Update README integrity blocks
    │   └── verify_integrity.py         # CI verification script
    └── assets/
        └── ci.yml                       # GitHub Actions workflow template
```

## Test plan

- [x] All 13 files present in correct directory structure
- [x] `plugin.json` follows existing schema (`gh-sdlc`, `ccgraft`)
- [x] `SKILL.md` relative paths (`./references/`, `./scripts/`, `./assets/`) resolve correctly from skill directory
- [x] `README.md` matches repo documentation conventions
