### PR TITLE
gh-63: revise `hypersaint` — abstract philosophy, strictness axiom, `[references]` table

### DIFF
--- a/plugins/hypersaint/README.md
+++ b/plugins/hypersaint/README.md
@@ -1,87 +1,28 @@
 # hypersaint
 
-A Claude Code plugin that enforces hypermodular, maximally strict repository architecture for codebases primarily or fully created and maintained by LLM agents.
+An LLM-native repository architecture framework. Every decision optimizes for an agent that reads only what it needs, when it needs it, and never the whole codebase at once.
 
-## Overview
+## Two Pillars
 
-Hypersaint is a language-agnostic architecture framework built on two pillars:
+**Hyperstrictness** — Every configurable dial turned to maximum correctness. Ten dimensions of strictness applied to every decision surface: structural, behavioral, data lifecycle, temporal, communication, error domain, resource, observability, operational, and security. The wrong thing is not discouraged — it is structurally inexpressible.
 
-1. **Hyperstrictness** — Every configurable dial turned to maximum correctness. Tooling that enforces rather than suggests. Ceremony that eliminates ambiguity.
-2. **Hypermodularity** — Aggressively decomposed directory structure with progressive disclosure at every level. Self-describing atoms navigable without loading the full repo.
+**Hypermodularity** — Aggressively decomposed directory structure with progressive disclosure at every level. Every directory is a self-describing atom with machine-readable manifests (`index.toml`), progressive disclosure documentation (`README.md`), cross-validated integrity hashes, and soft reference links. An agent navigates root → target by reading one manifest at each level.
 
-Every decision optimizes for an agent that reads only what it needs, when it needs it, and never the whole codebase at once.
+## Who It's For
 
-## Skills
+Codebases primarily or fully created and maintained by LLM agents. Hypersaint trades developer experience for maximum correctness — tedium has zero cost when the maintainer doesn't get bored.
 
-| Skill | Purpose |
-|-------|---------|
-| **hypersaint** | Architecture orchestrator. Guides project setup, directory structure, manifest creation, CI integrity, and MCP server implementation following the Hypersaint framework. |
+## What You Get
 
-## The Atom
-
-The atomic unit of work is a **directory** containing tightly related files for one concept:
-
-```
-any-directory/
-├── README.md          # Progressive disclosure docs (integrity hashes of siblings)
-├── index.toml         # Machine-readable manifest (exports, deps, integrity hashes)
-├── implementation     # Source files (< 200 lines each)
-└── tests/             # Unit + property-based tests (< 400 lines each)
-```
-
-- `README.md` hashes `index.toml`. `index.toml` hashes `README.md`. CI verifies both.
-- An agent navigates root → target by reading one manifest at each level.
-- No level requires loading its children to understand itself.
-
-## Reference Documents
-
-Loaded on-demand by the skill — never all at once.
-
-| Document | When to Load |
-|----------|-------------|
-| `philosophy.md` | Project setup, tool selection, dependency decisions |
-| `modularity.md` | Creating directory structure, organizing code |
-| `readme_format.md` | Writing or updating any `README.md` |
-| `index_toml_spec.md` | Creating or updating any `index.toml` |
-| `ci_integrity.md` | Setting up or modifying CI pipeline |
-| `mcp_server_spec.md` | Building the Hypersaint navigation MCP server |
-
-## Scripts
-
-| Script | Purpose | Usage |
-|--------|---------|-------|
-| `index_toml_generator.py` | Generate/update `index.toml` for a directory | `python scripts/index_toml_generator.py <target_dir>` |
-| `readme_hooks.py` | Top-down `README.md` update after changes | `python scripts/readme_hooks.py <root_dir> --changed <file1> <file2>` |
-| `verify_integrity.py` | CI integrity verification | `python scripts/verify_integrity.py . --strict` |
-
-## Assets
-
-| Asset | Purpose |
-|-------|---------|
-| `ci.yml` | GitHub Actions workflow template for integrity verification |
-
-## Key Conventions
-
-### Strictness
-- Maximum strictness on all linters and type checkers — no exceptions without commented justification
-- Exhaustive static typing — no `Any`, no untyped public API surface
-- Runtime validation (Pydantic, Zod, beartype) at every trust boundary
-- `__slots__` in Python, explicit interfaces in TypeScript
-- `__all__` in every Python file, explicit exports in TypeScript
-- Docstrings on every public symbol
-- Unit tests + property-based tests for every public function
-
-### Modularity
-- Directories are atoms — one concept per directory
-- Every directory has `README.md` + `index.toml` with cross-validated integrity hashes
-- DRY is supreme — shared utilities at the lowest common ancestor
-- Circular dependencies must be declared in both atoms with justification
-- Updating manifests is part of every change — CI enforces this
+- A complete architecture and ruleset (philosophy, modularity, strictness dimensions)
+- Progressive disclosure README format with MCP server specification
+- Machine-readable `index.toml` manifests with integrity hashes and soft references
+- CI integrity verification pipeline (GitHub Actions template + verification script)
+- Scripts for manifest generation and maintenance
 
 ## Requirements
 
 - Python 3.10+ (scripts use only stdlib)
-- A project where LLM agents are the primary maintainers
 
 ## Installation
 

--- a/plugins/hypersaint/skills/hypersaint/SKILL.md
+++ b/plugins/hypersaint/skills/hypersaint/SKILL.md
@@ -49,29 +49,48 @@ These rules are non-negotiable. Every Hypersaint repository must satisfy all of 
 
 ### Strictness Rules
 
-1. **Every configurable strictness dial is at maximum.** Pyright strict mode. TypeScript `strict: true`
-   plus all pedantic flags. Ruff with all applicable rules enabled. No exceptions without explicit,
-   commented justification citing the specific error code.
-2. **Prefer tools that unify and enforce.** Ruff over flake8+isort+black. Biome over ESLint+Prettier.
-   Bun over Node. The tool that makes the wrong thing a hard error wins.
-3. **Static typing is exhaustive.** Every function has full parameter and return annotations. No `Any`.
-   No untyped public API surface. Runtime validation (Pydantic, Zod, beartype) at every trust boundary.
-4. **Every class declares its shape explicitly.** `__slots__` in Python. Explicit interfaces in TypeScript.
-   No implicit attribute creation.
-5. **Every module declares its public surface.** `__all__` in every Python file and `__init__.py`.
-   Explicit exports in TypeScript. No namespace pollution.
+0. **Every strictness dimension applies.** The dimensions described in the Philosophy reference
+   (structural, behavioral, data lifecycle, temporal, communication, error domain, resource,
+   observability, operational, security) govern every decision. The rules below are common
+   instances of those dimensions, not the exhaustive list. The agent must identify and apply
+   the relevant strictness dimensions for every decision it makes.
+1. **Every configurable strictness dial is at maximum.** The language's type checker, linter, and
+   formatter must all run at their strictest settings. No exceptions without explicit, commented
+   justification citing the specific error code. (E.g., Pyright strict mode, TypeScript `strict: true`
+   plus all pedantic flags, Clippy with all lints in Rust.)
+2. **Prefer tools that unify and enforce.** When multiple tools cover overlapping concerns, choose the
+   single tool that consolidates them and makes the wrong thing a hard error. Fewer tools with broader
+   scope beat many tools with narrow scope. (E.g., Ruff over flake8+isort+black, Biome over
+   ESLint+Prettier.)
+3. **Static typing is exhaustive.** Every function has full parameter and return annotations. No escape
+   hatches from the type system. No untyped public API surface. Runtime validation at every trust
+   boundary using the language's canonical schema validation library.
+4. **Every data structure declares its shape explicitly.** No attribute, field, or member may exist at
+   runtime that is not declared in the structure's definition. Dynamic attribute creation and implicit
+   field inheritance are prohibited.
+5. **Every module declares its public surface.** Every file and package must explicitly enumerate what
+   it exports. No namespace pollution — consumers see only what the author intended. (E.g., `__all__`
+   in Python, explicit `export` in TypeScript, `pub` visibility in Rust.)
 6. **Every public symbol has a docstring.** Functions, classes, methods, modules. The docstring is the
    contract the next agent reads instead of the implementation.
-7. **Tests are mandatory and layered.** Unit tests for known cases. Property-based tests (Hypothesis,
-   fast-check) for invariants. Both required for every public function.
+7. **Tests are mandatory and layered.** Unit tests for known cases. Property-based tests for invariants.
+   Both required for every public function. Use the language's canonical property-based testing library.
+   (E.g., Hypothesis for Python, fast-check for TypeScript, proptest for Rust.)
 8. **Dependencies must be proven.** High adoption, active maintenance, trusted maintainers. Never
    author security-sensitive code — wrap proven libraries so tightly that misuse is a type error.
-9. **Infrastructure is code.** Dev environment (Nix flakes), cloud resources (Terraform/Pulumi),
-   CI/CD, configuration (typed + validated at startup), containers (multi-stage, distroless).
+9. **Infrastructure is code.** Dev environment, cloud resources, CI/CD, configuration, and containers
+   are all declared in version-controlled, reproducible configuration files. Configuration must be
+   typed and validated at startup. (E.g., Nix flakes, Terraform/Pulumi, multi-stage distroless
+   container builds.)
 10. **The feedback loop is sacred.** Every change runs the full strictness suite. The agent loops
-    until it passes. Fast tools (Ruff, Biome, Pyright) are mandatory — speed enables tight loops.
+    until it passes. Fast tooling is mandatory — speed enables tight loops.
 
 ### Modularity Rules
+
+The modularity rules below are the structural strictness dimension applied to code organization. The
+reason every directory has manifests, the reason boundaries are enforced by the integrity system, the
+reason DRY is supreme — is because these rules make incorrect organizational states structurally
+inexpressible.
 
 1. **Directories are atoms.** The atomic unit of work is a directory containing tightly related files
    for one concept. The agent loads one atom, understands it fully, modifies it, and puts it back.

--- a/plugins/hypersaint/skills/hypersaint/references/index_toml_spec.md
+++ b/plugins/hypersaint/skills/hypersaint/references/index_toml_spec.md
@@ -8,9 +8,10 @@
 4. [Hash Computation](#hash-computation)
 5. [Dependency Declarations](#dependency-declarations)
 6. [Circular Dependencies](#circular-dependencies)
-7. [Description Field](#description-field)
-8. [Examples](#examples)
-9. [Validation Rules](#validation-rules)
+7. [Soft References](#soft-references)
+8. [Description Field](#description-field)
+9. [Examples](#examples)
+10. [Validation Rules](#validation-rules)
 
 ---
 
@@ -47,6 +48,12 @@ symbols = ["LoginHandler", "LoginConfig", "LoginError"]
 [circular]
 # Only present if circular dependencies exist. See Circular Dependencies section.
 # "src.features.auth.session" = "Session needs LoginError type for error propagation"
+
+[references]
+# Only present if soft references exist. See Soft References section.
+# [[references."local_file"]]
+# path = "repo/relative/path"
+# rel = "relationship_type"
 
 [integrity]
 # SHA-256 hashes of every sibling file/directory, excluding index.toml itself.
@@ -105,6 +112,17 @@ If the atom has no external dependencies, this table is present but empty: `[dep
 ### `[circular]`
 
 Present ONLY if circular dependencies exist. See Circular Dependencies section below.
+
+### `[references]`
+
+Present ONLY if semantic cross-references exist between files in this atom and files elsewhere
+in the repository.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| Keys | String (local filename) | - | Relative path to the local file being cross-referenced |
+| `path` | String | Yes | Path to the referenced file, relative to repo root |
+| `rel` | String | Yes | Relationship type from the known set |
 
 ### `[integrity]`
 
@@ -226,6 +244,61 @@ Circular dependencies are not banned but must be declared, justified, and ideall
 
 ---
 
+## Soft References
+
+The `[references]` table declares semantic relationships between files that are not import
+dependencies. These are many-to-many cross-links: a documentation file documents an implementation
+file, a generated artifact derives from a source template, a config file governs a service file.
+
+### Schema
+
+```toml
+[references]
+# Keys are local files (relative to this directory).
+# Values are arrays of tables with `path` (relative to repo root) and `rel` (relationship type).
+
+[[references."docs/api_reference.html"]]
+path = "src/features/download/downloader.py"
+rel = "documents"
+
+[[references."docs/api_reference.html"]]
+path = "src/features/upload/uploader.py"
+rel = "documents"
+
+[[references."config/download_limits.toml"]]
+path = "src/features/download/downloader.py"
+rel = "configures"
+```
+
+### Relationship Types
+
+| Type | Meaning | Inverse |
+|------|---------|---------|
+| `documents` | This file documents the target | `documented-by` |
+| `documented-by` | This file is documented by the target | `documents` |
+| `generates` | This file is the source that generates the target | `generated-from` |
+| `generated-from` | This file was generated from the target | `generates` |
+| `configures` | This file configures the behavior of the target | `configured-by` |
+| `configured-by` | This file's behavior is configured by the target | `configures` |
+| `tests` | This file tests the target (beyond co-located test files) | `tested-by` |
+| `tested-by` | This file is tested by the target | `tests` |
+| `related` | General semantic relationship (use sparingly; prefer specific types) | `related` |
+
+### Rules
+
+1. **Paths in `path` must point to existing files.** Non-existent reference targets are hard
+   failures in CI.
+2. **Relationship types must be from the known set.** Unknown relationship types are errors.
+3. **Many-to-many is expected.** A single file can reference multiple targets, and a single
+   target can be referenced by multiple files across different atoms.
+4. **Inverse declarations are encouraged but not required.** If atom A says file X `documents`
+   file Y, atom B (containing Y) may optionally declare Y as `documented-by` X. The MCP server
+   can infer inverse relationships from one-sided declarations.
+5. **`related` is the escape hatch.** Use it only when no specific type fits. Overuse of
+   `related` signals that a new relationship type should be proposed.
+
+---
+
 ## Description Field
 
 The optional top-level `description` field is governed by strict rules to prevent it from becoming
@@ -339,7 +412,7 @@ symbols = ["generate_figure", "FigureConfig"]
 CI and the MCP server validate index.toml against these rules:
 
 1. **Schema compliance.** All tables must be from the known set: `exports`, `dependencies`,
-   `circular`, `integrity`, `children`. Unknown tables are errors.
+   `circular`, `references`, `integrity`, `children`. Unknown tables are errors.
 2. **Hash accuracy.** Every hash in `[integrity]` must match the recomputed hash of the
    corresponding file or directory. Mismatches are hard failures.
 3. **Completeness.** Every file and directory sibling to index.toml must have an entry in
@@ -354,3 +427,7 @@ CI and the MCP server validate index.toml against these rules:
    not always a hard failure depending on language.)
 7. **Description length.** If `description` is present, it must be ≤ 2 sentences. Enforced by
    counting sentence-ending punctuation (`.`, `!`, `?`).
+8. **Reference target existence.** Every `path` in `[references]` must point to a file that
+   exists in the repository. Non-existent targets are hard failures.
+9. **Reference relationship validity.** Every `rel` in `[references]` must be from the known
+   set of relationship types. Unknown types are hard failures.

--- a/plugins/hypersaint/skills/hypersaint/references/mcp_server_spec.md
+++ b/plugins/hypersaint/skills/hypersaint/references/mcp_server_spec.md
@@ -156,8 +156,13 @@ IndexManifest:
   exports: list[str]                  # Symbol names
   dependencies: dict[str, list[str]]  # import_path → [symbols]
   circular: dict[str, str]            # import_path → justification
+  references: dict[str, list[Reference]]  # local_file → [Reference]
   integrity: dict[str, str]           # filename → sha256 hash
   children: dict[str, str]            # dirname → description
+
+Reference:
+  path: str                               # Repo-relative path to referenced file
+  rel: str                                # Relationship type
 ```
 
 ### Validation
@@ -168,6 +173,7 @@ On parse, validate:
 - All values are the expected types.
 - If `[circular]` exists, values are non-empty strings (justifications).
 - If `[children]` exists, every listed directory actually exists on disk.
+- If `[references]` exists, every `path` must point to an existing file. Every `rel` must be from the known relationship types.
 
 Return validation errors as structured data, not exceptions.
 
@@ -198,6 +204,7 @@ atom's export/dependency information.
    - The children dict (if non-leaf)
    - The description (if present in index.toml)
    - Whether circular dependencies exist (boolean flag — details loaded separately)
+   - Soft references summary (count and relationship types, if any exist)
 
 **Response format:**
 Return as structured text. Example:
@@ -221,6 +228,10 @@ Handles all authentication and authorization flows.
 
 ## Circular Dependencies
 None declared.
+
+## Soft References
+- docs/api_reference.html documents src/features/auth/login/login.py
+- config/auth_limits.toml configures src/features/auth/login/login.py
 ```
 
 ### `readme`
@@ -312,6 +323,7 @@ src/
 | `path` | string | Yes | Path relative to repo root |
 | `direction` | string | No | `outgoing` (what this atom depends on), `incoming` (what depends on this atom), or `both`. Default: `both`. |
 | `recursive` | boolean | No | If true, follow dependency chains transitively. Default: false. |
+| `include_references` | boolean | No | Include soft reference relationships alongside import dependencies. Default: true. |
 
 **Behavior:**
 1. Read the target atom's `index.toml` for outgoing dependencies.
@@ -338,6 +350,11 @@ src/
 ## Circular Dependencies
 - src.features.auth.session ↔ src.features.auth.login
   Reason: Session imports LoginError for error propagation.
+
+## Soft References
+- config/auth_limits.toml configures login.py
+- docs/api_reference.html documents login.py
+- login.py is documented-by docs/api_reference.html
 ```
 
 ### `integrity`

--- a/plugins/hypersaint/skills/hypersaint/references/modularity.md
+++ b/plugins/hypersaint/skills/hypersaint/references/modularity.md
@@ -27,11 +27,15 @@ Hypersaint modularity resolves the tension between **navigability** (the LLM nee
 right piece fast) and **isolation** (once it finds the piece, it should need nothing else to work
 on it).
 
-The key insight: in a hypermodular repo with full type annotations, docstrings, and `__all__`
-declarations, the agent working on module B does not need to read the *implementation* of a
+The key insight: in a hypermodular repo with full type annotations, docstrings, and explicit public
+surface declarations, the agent working on module B does not need to read the *implementation* of a
 dependency — it reads the type signature and the docstring, which are the contract. DRY therefore
 *saves* context window rather than costing it, because a shared utility's contract is loaded once
 and is far smaller than duplicated implementations.
+
+The modularity system is the structural strictness dimension (see Philosophy) applied to code
+organization. Every manifest, every boundary, every integrity check exists to make incorrect
+organizational states structurally inexpressible rather than conventionally discouraged.
 
 ---
 
@@ -62,14 +66,15 @@ Rules for atom contents:
    represents a single cohesive concept, it should be split into a sub-atom (a subdirectory with
    its own README.md and index.toml).
 4. **Test files** — Co-located. Always. The agent loading this atom has everything it needs to
-   understand and verify the code. Test file names mirror implementation file names with a `test_`
-   prefix (Python) or `.test.` infix (TypeScript) or `_test` suffix (Rust/Go).
+   understand and verify the code. Test file names mirror implementation file names using the
+   language's standard test naming convention (e.g., `test_` prefix in Python, `.test.` infix in
+   TypeScript, `_test` suffix in Rust/Go).
 5. **Test fixtures** — Co-located inside the atom if they are specific to this atom. Shared test
    infrastructure (factories, builders, mock servers) lives at a semantically named shared path
    under the lowest common ancestor.
-6. **No configuration files at the atom level.** Tooling configuration (pyproject.toml, biome.json,
-   Cargo.toml) lives at the repository root or at the top-level project boundary. Atoms inherit
-   configuration. They do not override it.
+6. **No configuration files at the atom level.** Language-level configuration files (build system
+   config, linter config, etc.) live at the repository root or at the top-level project boundary.
+   Atoms inherit configuration. They do not override it.
 
 ### What Does NOT Live Inside an Atom
 
@@ -296,10 +301,10 @@ does not impose a layer cake. However:
    and should be restructured. This is a **soft rule** — if restructuring would create worse
    problems (duplication, artificial indirection), the cycle can remain with justification.
 
-3. **Import linting is mandatory.** Use tooling to enforce dependency rules:
-   - Python: `import-linter` or `ruff` import rules
-   - TypeScript: `eslint-plugin-import` or Biome import rules
-   - Rust: `cargo-deny` for crate-level, module visibility for internal
+3. **Import linting is mandatory.** Use automated tooling to enforce dependency rules. Every
+   language ecosystem has tools that can verify import boundaries and flag violations as hard errors.
+   (E.g., `import-linter` or `ruff` import rules in Python, Biome import rules in TypeScript,
+   `cargo-deny` and module visibility in Rust.)
 
 ---
 
@@ -382,11 +387,13 @@ principles:
 
 ### Imports
 
-- **Absolute imports from the project root.** `from src.features.auth.login.login import LoginHandler`.
-  Never relative imports that navigate upward (`from ...format import ...`). Absolute imports are
-  greppable and unambiguous.
-- **Import the symbol, not the module** (where language conventions permit). `from module import Class`
-  over `import module` in Python. Named imports in TypeScript/JavaScript.
+- **Absolute imports from the project root.** All imports use fully qualified paths rooted at the
+  project boundary. Relative imports that navigate upward are prohibited. Absolute imports are
+  greppable and unambiguous. (E.g., `from src.features.auth.login.login import LoginHandler` in
+  Python, not `from ...format import ...`.)
+- **Import the symbol, not the module** (where language conventions permit). Import the specific
+  name you need, not the containing namespace. This makes dependencies explicit and greppable.
+  (E.g., `from module import Class` over `import module` in Python, named imports in TypeScript.)
 
 ---
 

--- a/plugins/hypersaint/skills/hypersaint/references/philosophy.md
+++ b/plugins/hypersaint/skills/hypersaint/references/philosophy.md
@@ -3,13 +3,14 @@
 ## Table of Contents
 
 1. [The Foundational Axiom](#the-foundational-axiom)
-2. [Tool Selection Doctrine](#tool-selection-doctrine)
-3. [Code-Level Strictness](#code-level-strictness)
-4. [Dependency Philosophy](#dependency-philosophy)
-5. [Security Posture](#security-posture)
-6. [Infrastructure as Code](#infrastructure-as-code)
-7. [The Feedback Loop](#the-feedback-loop)
-8. [What Hypersaint Is Not](#what-hypersaint-is-not)
+2. [The Strictness Axiom](#the-strictness-axiom)
+3. [Tool Selection Doctrine](#tool-selection-doctrine)
+4. [Code-Level Strictness](#code-level-strictness)
+5. [Dependency Philosophy](#dependency-philosophy)
+6. [Security Posture](#security-posture)
+7. [Infrastructure as Code](#infrastructure-as-code)
+8. [The Feedback Loop](#the-feedback-loop)
+9. [What Hypersaint Is Not](#what-hypersaint-is-not)
 
 ---
 
@@ -29,6 +30,92 @@ mistake before it propagates.
 The codebase is the specification. The specification is the codebase. There is no gap between
 intent and implementation because every intent is encoded as a type, a contract, a test, a
 validation, or an assertion. Ambiguity is a defect.
+
+### Context Acquisition
+
+When the agent encounters a library, API, or system it doesn't fully understand, it must seek authoritative context via MCP servers, documentation fetch, or reference files before writing code. The agent does not guess. It does not rely on training data that may be stale. It acquires ground-truth context at the moment of need and acts on verified information. This is the enforcement-over-convention principle applied to the agent's own cognition.
+
+---
+
+## The Strictness Axiom
+
+Strictness is not a property of code. It is the system's relationship to ambiguity. Every decision surface in the system — architectural, behavioral, temporal, communicational, observational, operational, security — is governed by explicit, formal constraints that make incorrect states structurally inexpressible. The wrong thing is not discouraged. The wrong thing is not caught by a test. The wrong thing *cannot be expressed* in the first place. Where this ideal is unreachable, the system falls back through a hierarchy: compile-time enforcement, then static analysis, then runtime assertion, then validated convention with automated auditing — in that order, never skipping a level that is achievable.
+
+The following dimensions describe strictness as axes that the agent must apply to whatever system it is building. They are not code-specific — they apply to architecture, infrastructure, process, communication, and everything else.
+
+### Dimension 1: Structural Strictness
+
+The system's architecture enforces separation of concerns at the boundary level, not the convention level. Components cannot reach into each other's internals — not because a style guide says so, but because the architecture makes it structurally impossible.
+
+This means: dependency inversion enforced by the module system, not by developer discipline. Separation of reads and writes into structurally distinct paths where warranted. Domain core isolated from infrastructure at the compile-time level. If a component should not depend on another, the build system or module structure makes the import fail, not a linter warning.
+
+The agent should evaluate every architectural decision against: "Can a future agent violate this boundary by accident?" If yes, the boundary is not strict enough.
+
+### Dimension 2: Behavioral Strictness
+
+Every stateful component has an explicit, finite state machine. States are enumerated. Transitions are enumerated. Invalid transitions are inexpressible in the type system or state definition. The system cannot enter an undefined state because undefined states do not exist in the model.
+
+No undefined behavior, no implementation-defined behavior, no reliance on implicit execution order. Every operation has a defined outcome for every possible input. Every branch is handled. Every match/switch is exhaustive. Every state machine has an explicit error state and explicit transitions into it.
+
+The agent should be able to look at any stateful component and enumerate every possible state and every possible transition without reading the implementation — because the state machine is declared, not emergent.
+
+### Dimension 3: Data Lifecycle Strictness
+
+Data has an explicit lifecycle: it enters through a validated boundary, flows through typed transformations, and exits through a defined output channel. At no point in this lifecycle is data in an ambiguous state — it is either unvalidated (and typed as such), validated (and typed as such, distinctly from unvalidated), or transformed (and typed as the result type).
+
+No global mutable state. No ambient data. No "just grab it from the context." Every piece of data a function uses arrives through its parameters or through explicitly declared, injected dependencies. Side channels do not exist.
+
+Immutability is the default expression of this: a value that has been validated and transformed should not be mutatable, because mutation would potentially invalidate the guarantees that the validation established. Mutable state exists only at explicitly designated mutation points (database writes, cache updates, state machine transitions) and nowhere else.
+
+### Dimension 4: Temporal Strictness
+
+Every operation that can block has an explicit timeout. Every chain of operations has a deadline that propagates through the call chain. No unbounded waits. No "eventually consistent" without explicit convergence bounds and monitoring for convergence failure.
+
+Retry policies are explicit, bounded, and use backoff. No infinite retry loops. No "retry until it works." Every retry policy has a circuit breaker. Every circuit breaker has an explicit half-open strategy.
+
+Ordering constraints are explicit. If operation A must happen before operation B, this is enforced by the type system or the control flow — not by documentation saying "make sure to call A before B." If causal ordering matters, it is encoded in the data flow (A's output is B's input), not in a comment.
+
+### Dimension 5: Communication Strictness
+
+Between components within the system: schema-validated, versioned contracts. No implicit protocol assumptions. No "just send a dict/object and the other side knows what to do." Every message has a schema. Every schema has a version. Breaking changes to schemas are structurally impossible through additive-only evolution or explicit versioned endpoints.
+
+Between the system and external services: the same. Every external API call goes through a typed client with a schema. No raw HTTP calls with string URLs and untyped response parsing. Idempotency keys on every mutating external call. Exactly-once semantics where needed, at-least-once with deduplication elsewhere.
+
+### Dimension 6: Error Domain Completeness
+
+Every possible failure mode is enumerated in the type system. Not "this function can throw" but "these are the exact failure types, each distinct, each carrying the context needed for the caller to make a decision." No catch-all error handlers. No swallowed errors. No error that disappears into a log without the calling code making an explicit decision about it.
+
+The error path is as well-designed as the success path. Error types carry enough context to be actionable. Error propagation is explicit (Result types, typed exceptions, discriminated unions). The agent reading a function's signature knows every way it can fail without reading the implementation.
+
+### Dimension 7: Resource Strictness
+
+Every acquired resource has a defined, deterministic release path. Connections, file handles, locks, memory allocations, temporary files — every acquisition is paired with a release, and the pairing is enforced by the language construct (RAII, context managers, try-with-resources, defer) rather than by developer memory.
+
+Resource limits are explicit and enforced. Maximum connections, maximum memory, maximum open file descriptors, maximum queue depth. Every limit has a defined behavior when reached (reject, backpressure, circuit-break) rather than undefined degradation.
+
+### Dimension 8: Observability Strictness
+
+The system is fully debuggable from its telemetry alone, without reproducing the issue. Every state transition emits a structured, typed event. Every error is recorded with full causal context. Every external interaction is traced with correlation IDs that span the full request lifecycle.
+
+This is not "add logging." This is: the observability layer is a formal model of the system's behavior, and the model is complete. If something happened, it is observable. If it is not observable, the system treats it as if it didn't happen.
+
+Audit trails are append-only and cannot be tampered with by the service that produces them. Security events (authentication, authorization, access to sensitive data) are always logged, always structured, and always shipped to a separate collection system.
+
+### Dimension 9: Operational Strictness
+
+Builds are reproducible: the same input always produces the same output. Builds are hermetic: no network access during build, no reliance on external state. Artifacts are signed. Deployments are verified against expected state, not just "pushed and hoped."
+
+No manual deployment. No hotfix that bypasses the verification pipeline. No "just SSH in and restart it." Every operational action is either automated (IaC, CI/CD) or explicitly forbidden. The system's operational posture is as strict as its code posture.
+
+Infrastructure is immutable where possible: servers are rebuilt, not patched. Containers are replaced, not updated in place. Configuration changes are deployments, not runtime mutations.
+
+### Dimension 10: Security Strictness
+
+Default-deny at every layer. Network perimeter, process permissions, file access, API authorization — everything starts closed and is opened only with explicit justification. Defense in depth: no single security control is the only thing preventing a class of attack.
+
+Credentials are never in plaintext, never in default paths, never in home directories. Dedicated credential storage with access auditing. Rotation automated. Leak detection in CI. Transport encrypted everywhere including internal service-to-service. Certificate pinning where feasible.
+
+The agent never implements security primitives. It wraps proven, audited libraries so tightly that the unsafe usage path does not exist in the API.
 
 ---
 
@@ -98,102 +185,51 @@ extrapolate the underlying principle to any language.
 
 ### Explicit Shape Declaration
 
-Every class, struct, or data type declares its own shape explicitly in the file where it is defined.
+**Every data structure declares its shape exhaustively at definition time.** No attribute, field, or member may exist at runtime that is not declared in the structure's definition. Dynamic attribute creation, monkey-patching, and implicit field inheritance are prohibited. The structure's definition is the single source of truth for what it contains.
 
-- **Python:** Every class defines `__slots__`. This forces explicit attribute declaration, prevents
-  typo-based silent attribute creation, reduces memory usage, and critically — tells any agent
-  reading the file exactly what attributes exist without chasing inheritance.
-- **TypeScript:** Every interface is explicit. No `any`, no implicit index signatures, no `Record`
-  where a proper interface belongs.
-- **Rust:** Structs derive only what they need. No blanket `#[derive(Clone, Debug, Default)]` unless
-  every trait is actually used.
+*Examples: Python `__slots__`, TypeScript explicit interfaces with no index signatures, Rust structs with explicit field declarations, Go structs with explicitly typed fields.*
 
 ### Namespace Hygiene
 
-Nothing leaks into a namespace by accident. The public surface of every module is a conscious,
-documented decision.
+**The public surface of every module is an explicit, conscious declaration — not an emergent property of what happens to be defined.** Nothing leaks into a namespace by accident. Every symbol that is accessible from outside the module is intentionally exported. Wildcard imports from consuming code are acceptable only when the exporting module explicitly constrains what the wildcard exposes.
 
-- **Python:** Every module declares `__all__`. Every package's `__init__.py` declares `__all__`.
-  Every re-export is intentional. `from module import *` in consuming code is acceptable *only*
-  because `__all__` guarantees it imports exactly what was intended.
-- **TypeScript:** Explicit `export` on every public symbol. No default exports (they create naming
-  ambiguity). Barrel files (`index.ts`) declare explicit re-exports.
-- **Rust:** `pub(crate)` over `pub` where full public visibility isn't needed. Explicit `pub use`
-  re-exports in `mod.rs` / `lib.rs`.
+*Examples: Python `__all__` on every module and package, TypeScript explicit named exports with no default exports, Rust `pub(crate)` over `pub` with explicit `pub use` re-exports, Go capitalized identifiers as the sole export mechanism.*
 
 ### Exhaustive Static Typing
 
-The strictest mode the type checker supports is always enabled.
+**The strictest mode the type checker supports is always enabled.** Every function has full parameter and return type annotations. Escape hatches from the type system (untyped casts, type suppression comments, top types used as concrete types) are prohibited except at boundaries with untyped external code — and at those boundaries, the untyped value is immediately narrowed through a typed wrapper. Every type suppression is tracked as technical debt and annotated with a specific error code and justification.
 
-- **Python:** Pyright in strict mode (`"typeCheckingMode": "strict"`). Every function has full
-  parameter and return type annotations. No `Any` unless interfacing with an untyped external
-  library — and then, the `Any` is immediately narrowed at the boundary via a typed wrapper.
-  No `# type: ignore` without a specific error code and a comment explaining why. Every
-  `# type: ignore[specific-code]` is tracked as technical debt.
-- **TypeScript:** `strict: true` plus: `noUncheckedIndexedAccess`, `exactOptionalPropertyTypes`,
-  `noPropertyAccessFromIndexSignature`, `noFallthroughCasesInSwitch`, `forceConsistentCasingInFileNames`.
-  No `as any`. No `@ts-ignore` — use `@ts-expect-error` with explanation if absolutely necessary.
-- **Rust:** `#![deny(clippy::all, clippy::pedantic)]`. Address or explicitly allow every warning
-  with justification.
+*Examples: Python Pyright strict mode with no bare `Any`, TypeScript `strict: true` plus `noUncheckedIndexedAccess` and `exactOptionalPropertyTypes`, Rust `#![deny(clippy::all, clippy::pedantic)]`, Go `go vet` plus `staticcheck` with all analyzers enabled.*
 
 ### Runtime Validation at Trust Boundaries
 
-Static types are a compile-time promise. Runtime validation is the proof. Data crossing a trust
-boundary — user input, API responses, file reads, environment variables, database results,
-deserialized payloads — is validated at the boundary with a schema.
+**Static types are a compile-time promise. Runtime validation is the proof.** Data crossing a trust boundary — user input, API responses, file reads, environment variables, database results, deserialized payloads — is validated at the boundary with a schema that produces a distinctly typed "validated" value. The system distinguishes validated from unvalidated data at the type level. Parse, don't validate: the validation step returns a typed result, not a boolean.
 
-- **Python:** Pydantic models for structured data. beartype decorators for function signatures
-  where Pydantic is too heavy. `pydantic.SecretStr` for sensitive values.
-- **TypeScript:** Zod schemas at every trust boundary. Parse, don't validate — `z.parse()` returns
-  typed data, not a boolean.
-- **Rust:** `serde` with `#[serde(deny_unknown_fields)]`. Newtype wrappers for validated primitives
-  (e.g., `EmailAddress(String)` that validates on construction).
+*Examples: Python Pydantic models and `SecretStr`, TypeScript Zod schemas with `z.parse()`, Rust `serde` with `#[serde(deny_unknown_fields)]` and newtype wrappers, Go struct validation tags with explicit error returns.*
 
 ### Error Handling
 
-Prefer explicit error-as-value patterns over thrown exceptions where the language supports it.
+**Every function's failure modes are explicit in its signature or contract.** Prefer error-as-value patterns over thrown/raised exceptions where the language supports it. When exceptions are idiomatic, catch the narrowest type and document every raisable exception. No catch-all handlers. No swallowed errors. Every error carries enough context for the caller to make a decision. The error path receives the same design rigor as the success path.
 
-- **Rust:** `Result<T, E>` everywhere. `?` operator for propagation. Custom error types via
-  `thiserror`. Never `unwrap()` in library code — only in tests or with a comment explaining why
-  the panic is logically impossible.
-- **TypeScript:** Discriminated union result types or a `Result<T, E>` library. `try/catch` only
-  at the outermost boundary (HTTP handler, CLI entry point). Inner code returns errors as values.
-- **Python:** Exceptions are idiomatic, so: never bare `except`. Always catch the narrowest
-  exception type. Document every exception a function can raise in its docstring. Consider
-  `returns` library for Result-type patterns in critical paths.
+*Examples: Rust `Result<T, E>` with `thiserror`, TypeScript discriminated union result types, Python narrowly-typed `except` clauses with documented `Raises:` sections, Go multi-return `(value, error)` with explicit error checks.*
 
 ### Documentation as Contract
 
-Every public symbol has a docstring or doc comment. This is not optional and it is not decoration.
-The docstring is the contract that tells the next agent what this unit does, what it accepts, what
-it returns, what it raises, and what invariants it maintains — without reading the implementation.
+**Every public symbol has a doc comment that constitutes a binding contract.** The documentation declares what the unit does, what it accepts, what it returns, what it raises or returns as errors, and what invariants it maintains — without requiring the reader to examine the implementation. This is not optional and it is not decoration. The doc comment is the specification that enables any agent to use the symbol correctly on first encounter.
 
-Format:
-- **Python:** Google-style docstrings. `Args:`, `Returns:`, `Raises:` sections mandatory for any
-  function with parameters. One-line summary mandatory for everything.
-- **TypeScript:** TSDoc (`/** */`). `@param`, `@returns`, `@throws` tags mandatory.
-- **Rust:** `///` doc comments. Examples in doc comments that compile and run via `cargo test`.
+*Examples: Python Google-style docstrings with `Args:`, `Returns:`, `Raises:` sections, TypeScript TSDoc with `@param`, `@returns`, `@throws` tags, Rust `///` doc comments with compilable examples, Go package-level and function-level comments per `godoc` convention.*
 
 ### Testing
 
-Tests are mandatory, layered, and co-located with the code they test.
+**Tests are mandatory, layered, and co-located with the code they test.** Every public function has at least one unit test verifying its contract (inputs to outputs, not implementation details). Every function with a meaningful invariant has a property-based test that expresses the invariant — unit tests are specific instances of it. Preconditions are asserted at function entry. Postconditions are asserted before return. These assertions are executable specifications, not defensive programming.
 
-- **Unit tests:** Every public function has at least one. Test the contract (inputs → outputs),
-  not the implementation.
-- **Property-based tests:** Every public function with a meaningful invariant has a property test.
-  Hypothesis (Python), fast-check (TypeScript), proptest (Rust). The property test expresses the
-  invariant; unit tests are specific instances of it.
-- **Contracts and invariants:** Assert preconditions at function entry. Assert postconditions before
-  return. These are not "defensive programming" — they are executable specifications that catch
-  violations at the earliest possible moment.
+*Examples: Python `pytest` with Hypothesis for property tests, TypeScript Vitest with fast-check, Rust built-in `#[test]` with proptest, Go table-driven tests with `testing/quick`.*
 
 ### Formatting
 
-Formatting is never manual and never debatable. The tool decides. The agent runs the formatter.
+**Formatting is never manual and never debatable.** A single formatter is configured once in the project's configuration file and run automatically. No overrides. No per-file exceptions. The tool decides; the agent runs it.
 
-- **Python:** Ruff format. Line length configured once in `pyproject.toml`. Never overridden.
-- **TypeScript:** Biome format. Configured once in `biome.json`.
-- **Rust:** `rustfmt` with `edition = 2021`. No overrides.
+*Examples: Python Ruff format, TypeScript/JavaScript Biome format, Rust `rustfmt`, Go `gofmt`.*
 
 ---
 
@@ -202,12 +238,10 @@ Formatting is never manual and never debatable. The tool decides. The agent runs
 ### Use Dependencies Aggressively — But Only Proven Ones
 
 A "proven" dependency satisfies ALL of:
-- **High adoption:** Significant GitHub stars, download counts, production usage.
+- **High adoption:** Significant community usage, download counts, production deployment.
 - **Active maintenance:** Recent commits, responsive to issues, regular releases.
-- **Trusted provenance:** Backed by a known organization (Microsoft, Google, Mozilla, etc.) or a
-  well-known maintainer with a track record.
-- **Type-safe:** Ships with types (TypeScript declarations, py.typed marker, etc.). An untyped
-  dependency cannot satisfy Hypersaint's static typing requirements.
+- **Trusted provenance:** Backed by a known organization or a well-known maintainer with a track record.
+- **Type-safe:** Ships with type definitions or type annotations native to the language's type system. An untyped dependency cannot satisfy Hypersaint's static typing requirements.
 
 If a battle-tested library exists, use it. Do not rewrite what the ecosystem has already solved
 and hardened through years of production use and security audits.
@@ -250,19 +284,22 @@ libraries. The agent NEVER writes custom implementations of any security-critica
 The wrapper around a security library must constrain the API so that:
 - The insecure configuration is a type error, not a runtime option.
 - Default parameters are the secure choice. There is no "easy insecure mode."
-- Sensitive values use dedicated types (`SecretStr`, `SecretBytes`) that prevent accidental
-  logging or serialization.
+- Sensitive values use dedicated opaque types that prevent accidental logging or serialization.
 - If a user can XSS themselves through your interface, that is a failure — regardless of how
   unlikely or trivial the vector is.
+
+*Examples: Python `SecretStr`/`SecretBytes`, Rust `secrecy::Secret<T>`, TypeScript branded types wrapping sensitive strings.*
 
 ### Trust Boundaries Are Explicit
 
 Every point where data enters the system from an external source is marked as a trust boundary.
 Data at trust boundaries is:
-1. Validated against a schema (Pydantic, Zod, serde).
+1. Validated against a schema.
 2. Sanitized for the context it will be used in (HTML escaping, SQL parameterization, etc.).
 3. Typed as "validated" after passing through the boundary — so consuming code can distinguish
    validated from unvalidated data at the type level.
+
+*Examples: Python Pydantic, TypeScript Zod, Rust `serde` with `deny_unknown_fields`, Go struct validation.*
 
 ---
 
@@ -274,28 +311,26 @@ deployment — is described in versioned, reviewable, reproducible files.
 
 ### Development Environment
 
-Nix flakes define the complete development shell. Every tool, every dependency, every version is
-pinned and reproducible. A new contributor (human or LLM) runs one command and gets the exact
-environment. No "install these six things and hope the versions align."
+Declarative environment definitions pin the complete development shell. Every tool, every
+dependency, every version is pinned and reproducible. A new contributor (human or LLM) runs one
+command and gets the exact environment. No "install these six things and hope the versions align."
 
-```
-flake.nix           # Pin all dev tools and system dependencies
-flake.lock          # Locked dependency graph
-.envrc              # direnv integration for automatic shell activation
-```
+*Examples: Nix flakes with `flake.nix` + `flake.lock` + `.envrc` for direnv integration, devcontainers with `devcontainer.json`, Hermit for hermetic per-project tooling.*
 
 ### Infrastructure
 
-Terraform, Pulumi, or equivalent. Cloud resources are code. DNS is code. Secrets management is
-code (sealed/encrypted, never plaintext in the repo). If it exists in production, it exists as a
-versioned file in the repository.
+Declarative infrastructure-as-code tooling. Cloud resources are code. DNS is code. Secrets
+management is code (sealed/encrypted, never plaintext in the repo). If it exists in production,
+it exists as a versioned file in the repository.
+
+*Examples: Terraform, Pulumi, AWS CDK, Crossplane.*
 
 ### CI/CD
 
 Pipelines are code in the repository. The full strictness suite runs on every change:
-1. Formatting check (Ruff format / Biome format)
-2. Linting (Ruff / Biome lint)
-3. Static type checking (Pyright / tsc)
+1. Formatting check
+2. Linting
+3. Static type checking
 4. Unit tests
 5. Property-based tests
 6. Security scanning (dependency audit, SAST)
@@ -306,28 +341,19 @@ pass/fail output it can self-correct from. Every failure message must be specifi
 
 ### Configuration
 
-Application config is typed and validated at startup, not read from loose env vars with string
-fallbacks.
+**Application config is typed and validated at startup, not read from loose environment variables with string fallbacks.** Missing or malformed config crashes at startup with a clear error identifying the specific field and expected type. Never silently fall back to a default for a required value. Environment-specific overrides (dev, staging, prod) are structured files validated against the same schema.
 
-- **Python:** Pydantic `BaseSettings` with validators. Missing or malformed config → crash at
-  startup with a clear error. Never silently fall back to a default for a required value.
-- **TypeScript:** Zod schema parsing `process.env` at startup. Invalid config → thrown error
-  with the specific field and expected type.
-- **Rust:** Typed config struct deserialized at startup via `serde`. Missing fields → panic with
-  field name and expected type.
-
-Environment-specific overrides (dev, staging, prod) are structured files (TOML, JSON), not ad-hoc
-env vars. Each override file is validated against the same schema.
+*Examples: Python Pydantic `BaseSettings`, TypeScript Zod schema parsing `process.env`, Rust typed config struct via `serde`, Go `envconfig` with struct tags.*
 
 ### Containerization
 
 - Multi-stage builds. Build stage installs dependencies and compiles. Final stage copies only
   artifacts.
-- Minimal final images. Distroless (Google) or scratch where possible. Alpine only if distroless
+- Minimal final images. Distroless or scratch where possible. Alpine only if distroless
   is genuinely impractical.
 - No shell in production images unless explicitly required and justified.
 - Health checks defined in the Dockerfile or compose file, not assumed.
-- Non-root user by default. `USER nobody` or equivalent.
+- Non-root user by default.
 
 ---
 
@@ -341,10 +367,9 @@ messages are specific, actionable, and parseable. The agent loops — fix, re-ru
 until the suite passes. Overkill is not in the vocabulary. The cost of running the suite ten
 times is zero. The cost of shipping a defect is nonzero.
 
-This is why tool selection matters so much. Fast tools (Ruff: milliseconds, Biome: milliseconds,
-Pyright: seconds) give the agent tight feedback loops. Slow legacy tools (pylint: many seconds,
-ESLint: seconds per file) make the loop expensive. Speed is not a developer-experience luxury —
-it is an agent-efficiency requirement.
+This is why tool selection matters so much. Fast tools give the agent tight feedback loops. Slow
+legacy tools make the loop expensive. Speed is not a developer-experience luxury — it is an
+agent-efficiency requirement.
 
 The ideal loop:
 1. Agent modifies an atom (one or a few files in one directory).
@@ -362,17 +387,18 @@ The ideal loop:
 fine. What matters is that side effects are explicit, typed, contained, and tested — not that they
 don't exist.
 
-**It is not about developer experience.** Verbose? Good. Ceremonial? Good. Requires writing
-`__slots__` on every class, `__all__` on every module, docstrings on every function, property tests
-for every invariant? Good. The maintainer doesn't get bored or frustrated.
+**It is not about developer experience.** Verbose? Good. Ceremonial? Good. Requires exhaustive
+shape declarations on every data structure, explicit export lists on every module, docstrings on
+every function, property tests for every invariant? Good. The maintainer doesn't get bored or
+frustrated.
 
 **It is not about shipping fast.** It is about shipping *correctly*. The first version may take
 longer. Every version after that is faster because the codebase is so well-constrained that changes
 are safe and isolated.
 
-**It is not language-specific.** The examples skew toward Python, TypeScript, and Rust because those
-are common LLM-maintained stacks. The philosophy applies to any language. The agent's job is to find
-the Hypersaint-aligned tools and patterns for whatever environment it encounters.
+**It is not language-specific.** The examples reference specific languages because concreteness aids
+understanding. The philosophy applies to any language. The agent's job is to find the
+Hypersaint-aligned tools and patterns for whatever environment it encounters.
 
 **It is not a framework.** Hypersaint is an architecture and a ruleset. It does not impose a
 directory naming scheme beyond the structural rules (README.md, index.toml). It does not require

--- a/plugins/hypersaint/skills/hypersaint/references/readme_format.md
+++ b/plugins/hypersaint/skills/hypersaint/references/readme_format.md
@@ -214,6 +214,13 @@ and forgets. If the event schema changes, both atoms must be updated.
 <!-- @/hs:section -->
 ```
 
+The Related Atoms section in README.md provides the **semantic narrative** — why the relationship
+matters and what to watch for when modifying either atom. The `[references]` table in `index.toml`
+carries the **machine-readable link** — which files reference which, with typed relationships. The
+README should not duplicate the raw reference data from `index.toml`; instead, it adds the context
+that helps the agent understand the *implications* of the relationship. The MCP server combines
+both sources to give the agent a complete picture.
+
 ### Examples / Usage
 
 Canonical usage snippets showing how the public API is meant to be called. Loadable per-API so

--- a/plugins/hypersaint/skills/hypersaint/scripts/index_toml_generator.py
+++ b/plugins/hypersaint/skills/hypersaint/scripts/index_toml_generator.py
@@ -10,7 +10,8 @@ Usage:
 Arguments:
     target_dir  Path to the directory to generate index.toml for.
     --update    If set, preserve existing [exports], [dependencies], [circular],
-                [children], and description fields. Only regenerate [integrity].
+                [children], [references], and description fields. Only regenerate
+                [integrity].
                 If not set, generate a skeleton index.toml with empty tables.
 
 Behavior:
@@ -19,8 +20,8 @@ Behavior:
     - Computes SHA-256 hash of each file.
     - For subdirectories, computes SHA-256 of their index.toml (errors if missing).
     - Writes index.toml with sorted [integrity] entries.
-    - In --update mode: reads existing index.toml, preserves non-integrity tables,
-      replaces [integrity] with freshly computed hashes.
+    - In --update mode: reads existing index.toml, preserves non-integrity tables
+      (including [references]), replaces [integrity] with freshly computed hashes.
 
 Ignored Patterns:
     .git, __pycache__, node_modules, .mypy_cache, .ruff_cache, .pytest_cache,
@@ -39,8 +40,20 @@ import hashlib
 import os
 import sys
 from pathlib import Path
+from typing import Final
 
-IGNORE_DIRS: frozenset[str] = frozenset({
+__all__: list[str] = [
+    "sha256_file",
+    "sha256_directory",
+    "should_ignore",
+    "collect_entries",
+    "read_existing_toml",
+    "format_toml",
+    "generate_index_toml",
+    "main",
+]
+
+IGNORE_DIRS: Final[frozenset[str]] = frozenset({
     ".git",
     "__pycache__",
     "node_modules",
@@ -57,12 +70,12 @@ IGNORE_DIRS: frozenset[str] = frozenset({
     "*.egg-info",
 })
 
-IGNORE_FILES: frozenset[str] = frozenset({
+IGNORE_FILES: Final[frozenset[str]] = frozenset({
     ".DS_Store",
     "Thumbs.db",
 })
 
-IGNORE_EXTENSIONS: frozenset[str] = frozenset({
+IGNORE_EXTENSIONS: Final[frozenset[str]] = frozenset({
     ".pyc",
     ".pyo",
     ".pyd",
@@ -72,7 +85,14 @@ IGNORE_EXTENSIONS: frozenset[str] = frozenset({
 
 
 def sha256_file(path: Path) -> str:
-    """Compute SHA-256 hex digest of a file's raw bytes."""
+    """Compute SHA-256 hex digest of a file's raw bytes.
+
+    Args:
+        path: Path to the file.
+
+    Returns:
+        Hex-encoded SHA-256 digest.
+    """
     sha = hashlib.sha256()
     with path.open("rb") as f:
         for chunk in iter(lambda: f.read(8192), b""):
@@ -81,7 +101,17 @@ def sha256_file(path: Path) -> str:
 
 
 def sha256_directory(path: Path) -> str:
-    """Compute hash of a directory by hashing its index.toml content."""
+    """Compute hash of a directory by hashing its index.toml content.
+
+    Args:
+        path: Path to the directory.
+
+    Returns:
+        SHA-256 digest of the directory's index.toml.
+
+    Raises:
+        SystemExit: If the directory is missing its index.toml.
+    """
     index_path = path / "index.toml"
     if not index_path.exists():
         print(
@@ -94,7 +124,15 @@ def sha256_directory(path: Path) -> str:
 
 
 def should_ignore(name: str, is_dir: bool) -> bool:
-    """Check if a file or directory should be ignored."""
+    """Check if a file or directory should be ignored.
+
+    Args:
+        name: Name of the file or directory.
+        is_dir: Whether the entry is a directory.
+
+    Returns:
+        True if the entry should be ignored.
+    """
     if is_dir:
         return name in IGNORE_DIRS or name.endswith(".egg-info")
     if name in IGNORE_FILES:
@@ -103,7 +141,14 @@ def should_ignore(name: str, is_dir: bool) -> bool:
 
 
 def collect_entries(target_dir: Path) -> dict[str, str]:
-    """Collect all sibling files/dirs and their hashes, excluding index.toml itself."""
+    """Collect all sibling files/dirs and their hashes, excluding index.toml itself.
+
+    Args:
+        target_dir: Path to the directory to scan.
+
+    Returns:
+        Dictionary mapping filenames to SHA-256 hashes.
+    """
     entries: dict[str, str] = {}
 
     for item in sorted(target_dir.iterdir()):
@@ -125,7 +170,14 @@ def collect_entries(target_dir: Path) -> dict[str, str]:
 
 
 def read_existing_toml(path: Path) -> dict[str, object]:
-    """Read existing index.toml and return parsed tables (excluding [integrity])."""
+    """Read existing index.toml and return parsed tables (excluding [integrity]).
+
+    Args:
+        path: Path to the existing index.toml file.
+
+    Returns:
+        Parsed TOML data with the integrity table removed.
+    """
     if not path.exists():
         return {}
 
@@ -142,7 +194,15 @@ def read_existing_toml(path: Path) -> dict[str, object]:
 
 
 def format_toml(data: dict[str, object], integrity: dict[str, str]) -> str:
-    """Format a complete index.toml string from data tables and integrity hashes."""
+    """Format a complete index.toml string from data tables and integrity hashes.
+
+    Args:
+        data: Dictionary of non-integrity tables to serialize.
+        integrity: Dictionary mapping filenames to SHA-256 hashes.
+
+    Returns:
+        Formatted TOML string.
+    """
     lines: list[str] = []
 
     # Top-level description (optional)
@@ -163,18 +223,18 @@ def format_toml(data: dict[str, object], integrity: dict[str, str]) -> str:
     deps = data.get("dependencies", {})
     lines.append("[dependencies]")
     if isinstance(deps, dict) and deps:
-        for path, syms in sorted(deps.items()):
+        for dep_path, syms in sorted(deps.items()):
             if isinstance(syms, list):
                 syms_str = ", ".join(f'"{s}"' for s in syms)
-                lines.append(f'"{path}" = [{syms_str}]')
+                lines.append(f'"{dep_path}" = [{syms_str}]')
     lines.append("")
 
     # [circular] (only if present)
     circular = data.get("circular", {})
     if isinstance(circular, dict) and circular:
         lines.append("[circular]")
-        for path, justification in sorted(circular.items()):
-            lines.append(f'"{path}" = "{justification}"')
+        for circ_path, justification in sorted(circular.items()):
+            lines.append(f'"{circ_path}" = "{justification}"')
         lines.append("")
 
     # [children] (only if present)
@@ -184,6 +244,16 @@ def format_toml(data: dict[str, object], integrity: dict[str, str]) -> str:
         for name, desc in sorted(children.items()):
             lines.append(f'{name} = "{desc}"')
         lines.append("")
+
+    # [references] (only if present)
+    references = data.get("references", {})
+    if isinstance(references, dict) and references:
+        for ref_name, ref_data in sorted(references.items()):
+            lines.append(f"[references.{ref_name}]")
+            if isinstance(ref_data, dict):
+                for key, val in sorted(ref_data.items()):
+                    lines.append(f'{key} = "{val}"')
+            lines.append("")
 
     # [integrity]
     lines.append("[integrity]")
@@ -195,7 +265,12 @@ def format_toml(data: dict[str, object], integrity: dict[str, str]) -> str:
 
 
 def generate_index_toml(target_dir: Path, *, update: bool = False) -> None:
-    """Generate or update index.toml for the target directory."""
+    """Generate or update index.toml for the target directory.
+
+    Args:
+        target_dir: Path to the directory.
+        update: If True, preserve existing non-integrity tables.
+    """
     index_path = target_dir / "index.toml"
 
     # Collect integrity hashes
@@ -221,7 +296,7 @@ def generate_index_toml(target_dir: Path, *, update: bool = False) -> None:
 
 
 def main() -> None:
-    """Entry point."""
+    """Entry point for the index.toml generator."""
     if len(sys.argv) < 2:
         print("Usage: python index_toml_generator.py <target_dir> [--update]", file=sys.stderr)
         sys.exit(1)

--- a/plugins/hypersaint/skills/hypersaint/scripts/readme_hooks.py
+++ b/plugins/hypersaint/skills/hypersaint/scripts/readme_hooks.py
@@ -4,10 +4,15 @@ Given a set of changed files, determines ALL directories whose README.md integri
 blocks need updating, collects them top-down, and updates them in the correct order
 (leaf-first, then propagate upward to root).
 
+When running in ``--changed`` mode, the script also checks whether any changed file
+is a soft reference target in another atom's ``[references]`` table and emits a
+warning so the referencing atom can be reviewed for content accuracy.
+
 Usage:
     python readme_hooks.py <repo_root> --changed <file1> [file2 ...]
     python readme_hooks.py <repo_root> --directory <dir1> [dir2 ...]
     python readme_hooks.py <repo_root> --all
+    python readme_hooks.py <repo_root> --all --dry-run
 
 Arguments:
     repo_root       Path to the repository root.
@@ -38,6 +43,10 @@ Strategy:
        index.toml is now stale. Re-run index_toml_generator in --update mode for
        each affected directory.
 
+    5. SOFT REFERENCE WARNINGS: In --changed mode, after updating directories, scan
+       all index.toml [references] tables to find entries whose path matches a changed
+       file. Emit a warning for each match so referencing atoms can be reviewed.
+
 Exit Codes:
     0  Success (or dry-run)
     1  Invalid arguments
@@ -52,8 +61,29 @@ import os
 import re
 import sys
 from pathlib import Path
+from typing import Final
 
-IGNORE_DIRS: frozenset[str] = frozenset({
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib  # type: ignore[no-redef]
+
+__all__: list[str] = [
+    "sha256_file",
+    "sha256_directory",
+    "should_ignore",
+    "compute_integrity_entries",
+    "format_integrity_block",
+    "update_readme_integrity",
+    "find_affected_directories",
+    "find_all_directories",
+    "topological_sort_leaf_first",
+    "update_directory",
+    "check_soft_reference_targets",
+    "main",
+]
+
+IGNORE_DIRS: Final[frozenset[str]] = frozenset({
     ".git",
     "__pycache__",
     "node_modules",
@@ -70,12 +100,12 @@ IGNORE_DIRS: frozenset[str] = frozenset({
     ".github",
 })
 
-IGNORE_FILES: frozenset[str] = frozenset({
+IGNORE_FILES: Final[frozenset[str]] = frozenset({
     ".DS_Store",
     "Thumbs.db",
 })
 
-IGNORE_EXTENSIONS: frozenset[str] = frozenset({
+IGNORE_EXTENSIONS: Final[frozenset[str]] = frozenset({
     ".pyc",
     ".pyo",
     ".pyd",
@@ -83,12 +113,19 @@ IGNORE_EXTENSIONS: frozenset[str] = frozenset({
     ".dylib",
 })
 
-INTEGRITY_START = "<!-- @hs:integrity -->"
-INTEGRITY_END = "<!-- @/hs:integrity -->"
+INTEGRITY_START: Final[str] = "<!-- @hs:integrity -->"
+INTEGRITY_END: Final[str] = "<!-- @/hs:integrity -->"
 
 
 def sha256_file(path: Path) -> str:
-    """Compute SHA-256 hex digest of a file's raw bytes."""
+    """Compute SHA-256 hex digest of a file's raw bytes.
+
+    Args:
+        path: Path to the file.
+
+    Returns:
+        Hex-encoded SHA-256 digest.
+    """
     sha = hashlib.sha256()
     with path.open("rb") as f:
         for chunk in iter(lambda: f.read(8192), b""):
@@ -97,7 +134,14 @@ def sha256_file(path: Path) -> str:
 
 
 def sha256_directory(path: Path) -> str:
-    """Compute hash of a directory via its index.toml."""
+    """Compute hash of a directory via its index.toml.
+
+    Args:
+        path: Path to the directory.
+
+    Returns:
+        SHA-256 digest of the directory's index.toml, or a sentinel string if missing.
+    """
     index_path = path / "index.toml"
     if not index_path.exists():
         return "MISSING_INDEX_TOML"
@@ -105,7 +149,15 @@ def sha256_directory(path: Path) -> str:
 
 
 def should_ignore(name: str, is_dir: bool) -> bool:
-    """Check if a file or directory should be ignored."""
+    """Check if a file or directory should be ignored.
+
+    Args:
+        name: Name of the file or directory.
+        is_dir: Whether the entry is a directory.
+
+    Returns:
+        True if the entry should be ignored.
+    """
     if is_dir:
         return name in IGNORE_DIRS or name.endswith(".egg-info")
     if name in IGNORE_FILES:
@@ -114,7 +166,14 @@ def should_ignore(name: str, is_dir: bool) -> bool:
 
 
 def compute_integrity_entries(directory: Path) -> dict[str, str]:
-    """Compute hashes for all siblings of README.md in a directory (excluding README.md)."""
+    """Compute hashes for all siblings of README.md in a directory (excluding README.md).
+
+    Args:
+        directory: Path to the directory to scan.
+
+    Returns:
+        Dictionary mapping filenames to SHA-256 hashes.
+    """
     entries: dict[str, str] = {}
 
     for item in sorted(directory.iterdir()):
@@ -136,7 +195,14 @@ def compute_integrity_entries(directory: Path) -> dict[str, str]:
 
 
 def format_integrity_block(entries: dict[str, str]) -> str:
-    """Format entries as a markdown integrity table."""
+    """Format entries as a markdown integrity table.
+
+    Args:
+        entries: Dictionary mapping filenames to SHA-256 hashes.
+
+    Returns:
+        Formatted markdown integrity block string.
+    """
     lines: list[str] = [
         INTEGRITY_START,
         "## Integrity",
@@ -153,7 +219,15 @@ def format_integrity_block(entries: dict[str, str]) -> str:
 
 
 def update_readme_integrity(readme_path: Path, entries: dict[str, str]) -> bool:
-    """Update the integrity block in a README.md. Returns True if changed."""
+    """Update the integrity block in a README.md.
+
+    Args:
+        readme_path: Path to the README.md file.
+        entries: Dictionary mapping filenames to SHA-256 hashes.
+
+    Returns:
+        True if the file was changed.
+    """
     if not readme_path.exists():
         return False
 
@@ -189,6 +263,13 @@ def find_affected_directories(
     A directory is affected if:
     1. It directly contains a changed file.
     2. Any of its child directories were affected (propagation upward).
+
+    Args:
+        repo_root: Path to the repository root.
+        changed_files: List of absolute paths to changed files.
+
+    Returns:
+        Set of directory paths that need updating.
     """
     affected: set[Path] = set()
 
@@ -211,7 +292,14 @@ def find_affected_directories(
 
 
 def find_all_directories(repo_root: Path) -> set[Path]:
-    """Find all Hypersaint-managed directories (those with README.md or index.toml)."""
+    """Find all Hypersaint-managed directories (those with README.md or index.toml).
+
+    Args:
+        repo_root: Path to the repository root.
+
+    Returns:
+        Set of managed directory paths.
+    """
     result: set[Path] = set()
 
     for dirpath, dirnames, _filenames in os.walk(repo_root):
@@ -228,14 +316,26 @@ def find_all_directories(repo_root: Path) -> set[Path]:
 
 
 def topological_sort_leaf_first(directories: set[Path]) -> list[Path]:
-    """Sort directories deepest-first so leaf updates happen before parent updates."""
+    """Sort directories deepest-first so leaf updates happen before parent updates.
+
+    Args:
+        directories: Set of directory paths.
+
+    Returns:
+        Sorted list of directory paths, deepest first.
+    """
     return sorted(directories, key=lambda p: len(p.parts), reverse=True)
 
 
 def update_directory(directory: Path, *, dry_run: bool = False) -> tuple[bool, bool]:
     """Update README.md and index.toml integrity for a single directory.
 
-    Returns (readme_changed, index_changed).
+    Args:
+        directory: Path to the directory to update.
+        dry_run: If True, only print what would be done without writing.
+
+    Returns:
+        Tuple of (readme_changed, index_changed).
     """
     readme_path = directory / "README.md"
     index_path = directory / "index.toml"
@@ -268,8 +368,65 @@ def update_directory(directory: Path, *, dry_run: bool = False) -> tuple[bool, b
     return readme_changed, index_changed
 
 
+def check_soft_reference_targets(
+    repo_root: Path,
+    changed_files: list[Path],
+    managed_dirs: set[Path],
+) -> None:
+    """Check if changed files are soft reference targets and emit warnings.
+
+    Parses all index.toml files in managed directories looking for ``[references]``
+    entries whose ``path`` matches a changed file. For each match, prints a warning
+    so the referencing atom can be reviewed for content accuracy.
+
+    Args:
+        repo_root: Path to the repository root.
+        changed_files: List of absolute paths to changed files.
+        managed_dirs: Set of all managed directory paths.
+    """
+    # Build set of changed relative paths for fast lookup
+    changed_rel: set[str] = set()
+    for cf in changed_files:
+        try:
+            changed_rel.add(str(cf.relative_to(repo_root)))
+        except ValueError:
+            continue
+
+    if not changed_rel:
+        return
+
+    for directory in managed_dirs:
+        index_path = directory / "index.toml"
+        if not index_path.exists():
+            continue
+
+        try:
+            with index_path.open("rb") as f:
+                data = tomllib.load(f)
+        except Exception:
+            continue
+
+        references = data.get("references", {})
+        if not isinstance(references, dict) or not references:
+            continue
+
+        referencing_rel = str(index_path.relative_to(repo_root))
+
+        for _ref_name, ref_data in references.items():
+            if not isinstance(ref_data, dict):
+                continue
+
+            ref_path = ref_data.get("path", "")
+            if ref_path and ref_path in changed_rel:
+                print(
+                    f"SOFT_REFERENCE_TARGET_CHANGED: {referencing_rel} references "
+                    f"{ref_path} which was modified. Review {referencing_rel} "
+                    f"for content accuracy."
+                )
+
+
 def main() -> None:
-    """Entry point."""
+    """Entry point for the README hooks updater."""
     if len(sys.argv) < 3:
         print(
             "Usage:\n"
@@ -288,6 +445,8 @@ def main() -> None:
 
     dry_run = "--dry-run" in sys.argv
     args = [a for a in sys.argv[2:] if a != "--dry-run"]
+
+    changed_paths: list[Path] = []
 
     if "--all" in args:
         directories = find_all_directories(repo_root)
@@ -329,6 +488,10 @@ def main() -> None:
             readme_count += 1
         if index_changed:
             index_count += 1
+
+    # Soft reference target warnings (only in --changed mode)
+    if changed_paths:
+        check_soft_reference_targets(repo_root, changed_paths, directories)
 
     print()
     print(f"Summary: {readme_count} READMEs updated, {index_count} index.toml files updated.")

--- a/plugins/hypersaint/skills/hypersaint/scripts/verify_integrity.py
+++ b/plugins/hypersaint/skills/hypersaint/scripts/verify_integrity.py
@@ -23,6 +23,10 @@ Checks Performed:
     9. Cross-validation: README.md's hash of index.toml matches actual index.toml.
     10. Circular dependency symmetry: if A declares circular with B, B must
         declare circular with A.
+    11. Reference target existence: every path in [references] points to an
+        existing file in the repository.
+    12. Reference relationship validity: every rel in [references] is a known
+        relationship type.
 
 Output Format (default):
     One error per line:
@@ -46,13 +50,29 @@ import re
 import sys
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Final
 
 try:
     import tomllib
 except ImportError:
     import tomli as tomllib  # type: ignore[no-redef]
 
-IGNORE_DIRS: frozenset[str] = frozenset({
+__all__: list[str] = [
+    "IntegrityError",
+    "sha256_file",
+    "sha256_directory",
+    "should_ignore",
+    "parse_readme_integrity",
+    "parse_index_toml",
+    "get_actual_entries",
+    "check_directory",
+    "check_circular_symmetry",
+    "check_references",
+    "find_managed_directories",
+    "main",
+]
+
+IGNORE_DIRS: Final[frozenset[str]] = frozenset({
     ".git",
     "__pycache__",
     "node_modules",
@@ -69,12 +89,12 @@ IGNORE_DIRS: frozenset[str] = frozenset({
     ".github",
 })
 
-IGNORE_FILES: frozenset[str] = frozenset({
+IGNORE_FILES: Final[frozenset[str]] = frozenset({
     ".DS_Store",
     "Thumbs.db",
 })
 
-IGNORE_EXTENSIONS: frozenset[str] = frozenset({
+IGNORE_EXTENSIONS: Final[frozenset[str]] = frozenset({
     ".pyc",
     ".pyo",
     ".pyd",
@@ -82,8 +102,20 @@ IGNORE_EXTENSIONS: frozenset[str] = frozenset({
     ".dylib",
 })
 
-INTEGRITY_START = "<!-- @hs:integrity -->"
-INTEGRITY_END = "<!-- @/hs:integrity -->"
+INTEGRITY_START: Final[str] = "<!-- @hs:integrity -->"
+INTEGRITY_END: Final[str] = "<!-- @/hs:integrity -->"
+
+KNOWN_REFERENCE_RELS: Final[frozenset[str]] = frozenset({
+    "documents",
+    "documented-by",
+    "generates",
+    "generated-from",
+    "configures",
+    "configured-by",
+    "tests",
+    "tested-by",
+    "related",
+})
 
 
 @dataclass(frozen=True, slots=True)
@@ -145,7 +177,14 @@ def should_ignore(name: str, is_dir: bool) -> bool:
 
 
 def parse_readme_integrity(readme_path: Path) -> dict[str, str] | None:
-    """Parse the integrity block from a README.md. Returns None if no block found."""
+    """Parse the integrity block from a README.md.
+
+    Args:
+        readme_path: Path to the README.md file.
+
+    Returns:
+        Dictionary mapping filenames to SHA-256 hashes, or None if no block found.
+    """
     if not readme_path.exists():
         return None
 
@@ -174,7 +213,14 @@ def parse_readme_integrity(readme_path: Path) -> dict[str, str] | None:
 
 
 def parse_index_toml(index_path: Path) -> dict[str, object] | None:
-    """Parse index.toml. Returns None if file doesn't exist."""
+    """Parse index.toml.
+
+    Args:
+        index_path: Path to the index.toml file.
+
+    Returns:
+        Parsed TOML data as a dictionary, or None if the file doesn't exist.
+    """
     if not index_path.exists():
         return None
 
@@ -183,7 +229,15 @@ def parse_index_toml(index_path: Path) -> dict[str, object] | None:
 
 
 def get_actual_entries(directory: Path, *, exclude: str) -> dict[str, str]:
-    """Get actual file hashes for a directory, excluding the named file."""
+    """Get actual file hashes for a directory, excluding the named file.
+
+    Args:
+        directory: Path to the directory to scan.
+        exclude: Filename to exclude from the scan.
+
+    Returns:
+        Dictionary mapping filenames to SHA-256 hashes.
+    """
     entries: dict[str, str] = {}
 
     for item in sorted(directory.iterdir()):
@@ -204,7 +258,15 @@ def get_actual_entries(directory: Path, *, exclude: str) -> dict[str, str]:
 
 
 def check_directory(directory: Path, repo_root: Path) -> list[IntegrityError]:
-    """Run all integrity checks on a single directory."""
+    """Run all integrity checks on a single directory.
+
+    Args:
+        directory: Path to the directory to check.
+        repo_root: Path to the repository root.
+
+    Returns:
+        List of integrity errors found.
+    """
     errors: list[IntegrityError] = []
     rel = str(directory.relative_to(repo_root))
 
@@ -256,7 +318,7 @@ def check_directory(directory: Path, repo_root: Path) -> list[IntegrityError]:
                 errors.append(IntegrityError(
                     code="HASH_MISMATCH",
                     path=f"{rel}/{name}",
-                    message=f"Hash mismatch in index.toml",
+                    message="Hash mismatch in index.toml",
                     declared=declared,
                     actual=actual,
                 ))
@@ -267,7 +329,7 @@ def check_directory(directory: Path, repo_root: Path) -> list[IntegrityError]:
             errors.append(IntegrityError(
                 code="MISSING_ENTRY",
                 path=f"{rel}/{name}",
-                message=f"File exists but not in index.toml [integrity]",
+                message="File exists but not in index.toml [integrity]",
             ))
 
     # Check 4: index.toml extra entries
@@ -276,7 +338,7 @@ def check_directory(directory: Path, repo_root: Path) -> list[IntegrityError]:
             errors.append(IntegrityError(
                 code="EXTRA_ENTRY",
                 path=f"{rel}/{name}",
-                message=f"Entry in index.toml [integrity] but file does not exist",
+                message="Entry in index.toml [integrity] but file does not exist",
             ))
 
     # Checks 5-7: README.md integrity block
@@ -290,7 +352,7 @@ def check_directory(directory: Path, repo_root: Path) -> list[IntegrityError]:
                     errors.append(IntegrityError(
                         code="HASH_MISMATCH",
                         path=f"{rel}/{name}",
-                        message=f"Hash mismatch in README.md integrity block",
+                        message="Hash mismatch in README.md integrity block",
                         declared=declared,
                         actual=actual,
                     ))
@@ -300,7 +362,7 @@ def check_directory(directory: Path, repo_root: Path) -> list[IntegrityError]:
                 errors.append(IntegrityError(
                     code="MISSING_ENTRY",
                     path=f"{rel}/{name}",
-                    message=f"File exists but not in README.md integrity block",
+                    message="File exists but not in README.md integrity block",
                 ))
 
         for name in readme_integrity:
@@ -308,7 +370,7 @@ def check_directory(directory: Path, repo_root: Path) -> list[IntegrityError]:
                 errors.append(IntegrityError(
                     code="EXTRA_ENTRY",
                     path=f"{rel}/{name}",
-                    message=f"Entry in README.md integrity block but file does not exist",
+                    message="Entry in README.md integrity block but file does not exist",
                 ))
 
     elif readme_path.exists():
@@ -350,7 +412,15 @@ def check_circular_symmetry(
     repo_root: Path,
     all_dirs: list[Path],
 ) -> list[IntegrityError]:
-    """Check that circular dependency declarations are symmetric."""
+    """Check that circular dependency declarations are symmetric.
+
+    Args:
+        repo_root: Path to the repository root.
+        all_dirs: List of all managed directories.
+
+    Returns:
+        List of integrity errors for asymmetric circular declarations.
+    """
     errors: list[IntegrityError] = []
 
     # Collect all circular declarations
@@ -395,8 +465,78 @@ def check_circular_symmetry(
     return errors
 
 
+def check_references(
+    repo_root: Path,
+    all_dirs: list[Path],
+) -> list[IntegrityError]:
+    """Check that all [references] entries have valid targets and relationship types.
+
+    Args:
+        repo_root: Path to the repository root.
+        all_dirs: List of all managed directories.
+
+    Returns:
+        List of integrity errors for invalid reference targets or relationship types.
+    """
+    errors: list[IntegrityError] = []
+
+    for directory in all_dirs:
+        index_path = directory / "index.toml"
+        if not index_path.exists():
+            continue
+
+        data = parse_index_toml(index_path)
+        if data is None:
+            continue
+
+        references = data.get("references", {})
+        if not isinstance(references, dict) or not references:
+            continue
+
+        rel = str(directory.relative_to(repo_root))
+
+        for ref_name, ref_data in references.items():
+            if not isinstance(ref_data, dict):
+                continue
+
+            # Check 11: reference target existence
+            ref_path = ref_data.get("path", "")
+            if ref_path:
+                target = repo_root / ref_path
+                if not target.exists():
+                    errors.append(IntegrityError(
+                        code="REFERENCE_TARGET_MISSING",
+                        path=f"{rel}/index.toml",
+                        message=(
+                            f"Reference '{ref_name}' points to "
+                            f"'{ref_path}' which does not exist"
+                        ),
+                    ))
+
+            # Check 12: reference relationship validity
+            ref_rel = ref_data.get("rel", "")
+            if ref_rel and ref_rel not in KNOWN_REFERENCE_RELS:
+                errors.append(IntegrityError(
+                    code="INVALID_REFERENCE_TYPE",
+                    path=f"{rel}/index.toml",
+                    message=(
+                        f"Reference '{ref_name}' uses unknown relationship "
+                        f"type '{ref_rel}'"
+                    ),
+                ))
+
+    return errors
+
+
 def find_managed_directories(repo_root: Path) -> list[Path]:
-    """Find all directories that should be managed by Hypersaint."""
+    """Find all directories that should be managed by Hypersaint.
+
+    Args:
+        repo_root: Path to the repository root.
+
+    Returns:
+        List of paths to managed directories.
+    """
     result: list[Path] = []
 
     for dirpath, dirnames, _filenames in os.walk(repo_root):
@@ -414,7 +554,7 @@ def find_managed_directories(repo_root: Path) -> list[Path]:
 
 
 def main() -> None:
-    """Entry point."""
+    """Entry point for the integrity verification script."""
     if len(sys.argv) < 2:
         print(
             "Usage: python verify_integrity.py <repo_root> [--strict] [--json]",
@@ -439,6 +579,9 @@ def main() -> None:
 
     # Check circular symmetry across the whole repo
     all_errors.extend(check_circular_symmetry(repo_root, all_dirs))
+
+    # Check references across the whole repo
+    all_errors.extend(check_references(repo_root, all_dirs))
 
     # Output
     if use_json:


### PR DESCRIPTION
## Summary

- Make all rules language-agnostic: abstract principle first, language examples as footnotes across `philosophy.md`, `SKILL.md`, `modularity.md`
- Add The Strictness Axiom with 10 dimensions (structural through security) to `philosophy.md`, Rule 0 in `SKILL.md`, structural strictness link in `modularity.md`
- Add `[references]` soft cross-link table to `index_toml_spec.md`, surface in `mcp_server_spec.md` (`navigate`/`deps` tools), document in `readme_format.md`
- Add `[references]` validation to `verify_integrity.py`, soft reference target warnings to `readme_hooks.py`, serialization to `index_toml_generator.py`
- Apply Hypersaint strictness to all Python scripts (`__all__`, `Final`, full type annotations)
- Slim `README.md` to a marketplace pitch

Closes #63

## Changes

| File | What changed |
|------|-------------|
| `philosophy.md` | +Strictness Axiom (10 dims), +Context Acquisition, all rules → abstract principle + example footnotes |
| `SKILL.md` | +Rule 0 (dimensions apply), all rules → language-agnostic, +structural strictness paragraph |
| `modularity.md` | Language refs → abstract, +structural strictness link |
| `index_toml_spec.md` | +`[references]` table spec, 9 relationship types, validation rules 8-9 |
| `mcp_server_spec.md` | +`Reference` type, `navigate` shows refs, `deps` has `include_references` param |
| `readme_format.md` | +Guidance on README vs `index.toml` reference roles |
| `verify_integrity.py` | +`__all__`, `Final`, +`check_references()` (target existence, type validity) |
| `readme_hooks.py` | +`__all__`, `Final`, +`check_soft_reference_targets()` warnings |
| `index_toml_generator.py` | +`__all__`, `Final`, +`[references]` preservation and serialization |
| `README.md` | Slimmed from 100 to 41 lines — marketplace pitch only |

**Stats:** 10 files, +754 / -279 lines

## Test plan

- [x] All 3 Python scripts pass `py_compile` syntax check
- [x] `verify_integrity.py` validates `[references]` targets and relationship types
- [x] `readme_hooks.py` emits `SOFT_REFERENCE_TARGET_CHANGED` warnings for changed targets
- [x] `index_toml_generator.py` preserves `[references]` in `--update` mode
- [x] All rules in `SKILL.md` and `philosophy.md` are comprehensible without language knowledge
- [x] `README.md` is a concise marketplace pitch without internal implementation details
